### PR TITLE
T1.7 — KICS paper draft + architecture figure script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ data/
 *.ckpt
 *.pt
 wandb/
+
+# George's KICS paper artefacts (personal academic output, not project-tracked).
+# The slice's engineering work — code, tests, results dirs, figure scripts,
+# and the status pointer at `papers/team/george-kics-status.md` — stays
+# tracked. The paper itself (`.tex/.pdf/.bib/figures/`) lives only locally.
+papers/kics-george/

--- a/papers/team/george-kics-status.md
+++ b/papers/team/george-kics-status.md
@@ -1,0 +1,64 @@
+# Slice 1 — KICS paper status
+
+This is a project-tracked status pointer for George's KICS paper. The paper
+artefacts themselves (`main.tex`, `refs.bib`, `main.pdf`,
+`fig1-pipeline.pdf`, `SUBMISSION.md`) live under the gitignored
+`papers/kics-george/` directory on the AFK execution machine; they never
+appear in any PR diff. See the AFK plan's commit-boundary rationale at
+`docs/slice-1-afk-plan.md` section 1.
+
+## Draft state (2026-05-07)
+
+- **Local PDF**: `papers/kics-george/main.pdf` (2 pages, IEEEtran two-column,
+  198 KB).
+- **LaTeX source**: `papers/kics-george/main.tex` — full structure (abstract,
+  IEEE keywords, intro, methodology with two subsections, results table,
+  conclusion, acknowledgment, references). Uses the project-wide
+  acknowledgment block verbatim from the prior paper.
+- **References**: `papers/kics-george/refs.bib` — 7 entries (AutoFi, CAPC,
+  SimCLR, Widar3.0, Xu et al. SSL benchmark, two of George's prior works).
+  Each entry compiles cleanly via `bibtex`; substantive verification (open
+  the actual paper, confirm it says what the citation claims) is a T1.8
+  step per AFK plan section 7.8 / `docs/06-using-ai-well.md`.
+- **Figure 1**: rendered by `src/slices/george/figures.py` (project-tracked).
+  Output `papers/kics-george/fig1-pipeline.pdf` (gitignored). Style mirrors
+  the prior paper's Fig. 1 — left-to-right pipeline with Widar3.0 input,
+  two Doppler-warped views, encoder, NT-Xent loss, and a frozen-encoder
+  linear-probe branch. Regenerate with `python -m src.slices.george.figures`.
+- **Result numbers**: placeholders (`TBD ± TBD`) in the abstract and Table I.
+  Substituted in T1.8 once T1.6's multi-seed comparison produces real
+  numbers. The data access blocker on issue #35 is the upstream gate.
+
+## Compile from scratch
+
+```bash
+python -m src.slices.george.figures        # writes papers/kics-george/fig1-pipeline.pdf
+cd papers/kics-george
+pdflatex main.tex && bibtex main && pdflatex main.tex && pdflatex main.tex
+```
+
+`main.pdf` should land at exactly 2 pages.
+
+## Notes for the reviewer
+
+- Title carries "Towards" framing; drop it in T1.8 if the result clears the
+  convention rule (`mean(ours) > mean(baseline) + std(baseline)`).
+- The discussion paragraph and the conclusion's closing sentence are
+  marked with bracketed `[insert ...]` notes for T1.8 to flesh out once
+  the result sign is known. The negative-result protocol (AFK plan §11)
+  is already accommodated: only the title, abstract last sentence, and
+  discussion paragraph need to change.
+- The acknowledgment block matches the prior paper's wording verbatim
+  (see AFK plan section 11.3); please don't re-edit unless the funding
+  lines have changed.
+- No content from `papers/kics-george/` appears in this PR's diff. The
+  reviewer should pull the branch and run the compile-from-scratch
+  recipe above to inspect the actual PDF.
+
+## Status
+
+- [x] T1.7 — paper draft compiles cleanly, 2 pages, all citations resolved.
+- [ ] T1.8 — references verified one-by-one, result numbers substituted,
+      submission portal upload checklist (`papers/kics-george/SUBMISSION.md`,
+      gitignored) drafted, submission staged for George's manual portal
+      upload.

--- a/src/slices/george/figures.py
+++ b/src/slices/george/figures.py
@@ -1,0 +1,106 @@
+"""Architecture figure generation for the Slice 1 KICS paper.
+
+Produces ``papers/kics-george/fig1-pipeline.pdf``: a left-to-right pipeline
+showing the Widar3.0 CSI input, two Doppler-warped views, the tiny CNN
+encoder, the NT-Xent contrastive loss, and the downstream frozen-encoder
+linear-probe branch. Visual style mirrors the prior paper's Fig. 1.
+
+The rendered PDF lives under the gitignored ``papers/kics-george/``
+directory; this script is the project-tracked codebase for the figure so
+teammates can regenerate or restyle it.
+
+Run:
+    python -m src.slices.george.figures
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+from matplotlib.patches import FancyArrowPatch, FancyBboxPatch
+
+DEFAULT_OUT = Path("papers/kics-george/fig1-pipeline.pdf")
+
+
+def _box(ax, x, y, w, h, text, fc="#e8eef7"):
+    patch = FancyBboxPatch(
+        (x, y),
+        w,
+        h,
+        boxstyle="round,pad=0.04",
+        linewidth=1.0,
+        edgecolor="black",
+        facecolor=fc,
+    )
+    ax.add_patch(patch)
+    ax.text(x + w / 2, y + h / 2, text, ha="center", va="center", fontsize=8.5)
+
+
+def _arrow(ax, x1, y1, x2, y2):
+    arrow = FancyArrowPatch(
+        (x1, y1),
+        (x2, y2),
+        arrowstyle="-|>",
+        mutation_scale=11,
+        color="black",
+        linewidth=0.9,
+    )
+    ax.add_patch(arrow)
+
+
+def make_pipeline_figure(out_path: Path = DEFAULT_OUT) -> Path:
+    fig, ax = plt.subplots(figsize=(7.0, 2.8))
+    ax.set_xlim(0, 14)
+    ax.set_ylim(-1.2, 6)
+    ax.set_aspect("equal")
+    ax.axis("off")
+
+    _box(ax, 0.2, 2.2, 1.9, 1.6, "Widar3.0\nCSI sample", fc="#fff3cd")
+    _box(
+        ax,
+        3.1,
+        4.0,
+        2.4,
+        1.4,
+        "View 1\nDoppler warp\nfactor $f_1$",
+        fc="#d1ecf1",
+    )
+    _box(
+        ax,
+        3.1,
+        0.6,
+        2.4,
+        1.4,
+        "View 2\nDoppler warp\nfactor $f_2$",
+        fc="#d1ecf1",
+    )
+    _box(ax, 6.6, 2.2, 2.4, 1.6, r"Tiny CNN encoder $f_\theta$", fc="#e8eef7")
+    _box(ax, 10.1, 2.2, 1.8, 1.6, "NT-Xent\n(SimCLR)", fc="#f8d7da")
+    _box(
+        ax,
+        6.6,
+        -0.9,
+        5.3,
+        1.0,
+        r"Frozen $f_\theta$ + linear probe $\to$ cross-subject prediction",
+        fc="#d4edda",
+    )
+
+    _arrow(ax, 2.1, 3.4, 3.1, 4.6)
+    _arrow(ax, 2.1, 2.6, 3.1, 1.3)
+    _arrow(ax, 5.5, 4.6, 6.6, 3.4)
+    _arrow(ax, 5.5, 1.3, 6.6, 2.6)
+    _arrow(ax, 9.0, 3.0, 10.1, 3.0)
+    _arrow(ax, 7.8, 2.2, 7.8, 0.1)
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, bbox_inches="tight")
+    plt.close(fig)
+    return out_path
+
+
+if __name__ == "__main__":
+    saved = make_pipeline_figure()
+    print(f"wrote {saved}")


### PR DESCRIPTION
## What this does
Drafts the Slice 1 KICS paper locally and adds the project-tracked engineering artefacts that surface its existence:

- `src/slices/george/figures.py` — matplotlib script that renders Fig. 1 (left-to-right pipeline: Widar3.0 CSI sample → two Doppler-warped views → tiny CNN encoder → NT-Xent loss, with a frozen-encoder linear-probe branch). Style mirrors the prior paper's Fig. 1.
- `papers/team/george-kics-status.md` — status pointer that records what's local, what's still TBD, and how to recompile.
- `.gitignore` — adds `papers/kics-george/` so the `.tex/.pdf/.bib/figures` never leak into a PR diff (per AFK plan §1).

The local paper itself (`papers/kics-george/main.tex`, `refs.bib`, `main.pdf`, `fig1-pipeline.pdf`) is **not in this diff** — that's the AFK-plan-prescribed commit boundary for George's personal academic output.

## Why
Closes #40 (T1.7).

## How I tested it
- `python -m src.slices.george.figures` → renders `papers/kics-george/fig1-pipeline.pdf`.
- `cd papers/kics-george && pdflatex main.tex && bibtex main && pdflatex main.tex && pdflatex main.tex` → `main.pdf` lands at **exactly 2 pages**, 198 KB, no overfull / underfull / undefined-citation warnings. All 7 references resolve.
- `pytest tests/slices/george/`, `black --check .`, `ruff check .` — all clean.

## Anything reviewers should pay attention to
- **Targets `george/T1.1-scaffold`**, not `main`. Will auto-rebase once #83 lands.
- **Result numbers are placeholders** (`TBD ± TBD` in the abstract and Table I). T1.8 substitutes them once T1.6's multi-seed run produces real numbers — itself blocked on the data access issue on #35.
- **Discussion paragraph and conclusion's closing sentence** are bracketed `[insert ...]` notes; T1.8 fleshes them out depending on the result sign (positive vs negative-result framing per AFK plan §11).
- **Reference verification** is a T1.8 step (per `docs/06-using-ai-well.md`). I assembled the bibliography from the AFK plan section 11.4 list; each entry needs an actual paper-read pass before submission.
- The reviewer can pull this branch and run the compile-from-scratch recipe in `papers/team/george-kics-status.md` to inspect the actual PDF locally.