### PR TITLE
T1.8 (partial) — Paper polish: references verified, SUBMISSION.md staged

### DIFF
--- a/papers/team/george-kics-status.md
+++ b/papers/team/george-kics-status.md
@@ -58,7 +58,17 @@ pdflatex main.tex && bibtex main && pdflatex main.tex && pdflatex main.tex
 ## Status
 
 - [x] T1.7 — paper draft compiles cleanly, 2 pages, all citations resolved.
-- [ ] T1.8 — references verified one-by-one, result numbers substituted,
-      submission portal upload checklist (`papers/kics-george/SUBMISSION.md`,
-      gitignored) drafted, submission staged for George's manual portal
-      upload.
+- [x] T1.8 (partial) — references opened and verified one-by-one against
+      the published record; `papers/kics-george/refs.bib` corrected where
+      it diverged from reality (AutoFi: 7→5 authors, added vol/no/pages;
+      CAPC: full author list; Xu et al.: full author list).
+      `papers/kics-george/SUBMISSION.md` drafted (local-only checklist
+      with portal URL placeholder, deadline notes, per-reference
+      verification status, and the manual upload steps George runs).
+- [ ] T1.8 (data-blocked) — substitute placeholder result numbers in
+      Table I and the abstract once T1.6's multi-seed run produces them
+      (issue #35 is the upstream gate).
+- [ ] T1.8 (final) — write the discussion paragraph and conclusion's
+      closing sentence depending on whether the result clears the
+      convention rule. Drop "Towards" from the title if positive;
+      switch to a "Negative Result" framing if not.


### PR DESCRIPTION
## What this does
Picks up the data-independent half of T1.8 while T1.6's measurements remain blocked on the Widar3.0 access issue (#35).

- **Reference verification** (per `docs/06-using-ai-well.md`): opened each cited paper in the bibliography and confirmed it says what the citation claims. Three entries were corrected where the AFK-plan-suggested list diverged from the published record:
  - **AutoFi** — 7→5 authors; added vol/no/pages.
  - **CAPC** — replaced "Barahimi, B. and others" with the full 4-author list (Barahimi, Tabassum, Omer, Waqar).
  - **Xu et al. SSL benchmark** — replaced "Xu, K. and others" with the full 4-author list.
- **`papers/kics-george/SUBMISSION.md`** drafted (local-only, gitignored): portal-URL placeholder, deadline notes, per-reference verification table, and the manual upload steps George runs after the result numbers land.
- **`papers/team/george-kics-status.md`** updated (the only project-tracked change in this PR's diff) to reflect the new T1.8 state.

## Why
Partial close on #41 (T1.8). Full close lands once T1.6 produces real numbers and the discussion / abstract / Table I placeholders are substituted.

## How I tested it
- `pdflatex main.tex && bibtex main && pdflatex main.tex && pdflatex main.tex` — clean compile, exactly 2 pages, all 7 references resolve. No undefined citations, overfull, or underfull warnings.
- `python -m src.slices.george.figures` — figure regenerates cleanly.
- `pytest tests/slices/george/`, `black --check .`, `ruff check .` — green.

## Anything reviewers should pay attention to
- **Targets `george/T1.7-paper-draft`** (#87), not `main`. Stack: T1.1 → T1.7 → T1.8.
- **The `.tex/.bib/.pdf` edits live in the gitignored `papers/kics-george/`** and don't appear in this diff. Pull the branch and run the compile recipe in the status pointer to inspect locally.
- **Two refs (Akor 2025 PureChain, Akor 2026 EZKL)** — both verified to exist via web search; couldn't verify the exact published title vs the AFK plan §11.4 working title for the EZKL paper. Flagged in `SUBMISSION.md`'s reference verification table for George to confirm.
- **Result numbers, discussion paragraph, conclusion's closing sentence** all remain placeholders / bracketed `[insert ...]` notes — those land in a follow-up commit on this branch (or in T1.6's PR) once Widar3.0 data is in hand.