### PR TITLE
T3.2 — Real Widar3.0 cross-subject loader (csiread.Intel)

### DIFF
--- a/src/slices/collins/README.md
+++ b/src/slices/collins/README.md
@@ -19,10 +19,10 @@ chipset transfer — the slice's headline causal claim.
 
 | File | What it holds |
 |---|---|
-| `encoder.py` | `TinyCNN` (~40K params for Widar3.0 input shape) and the (T,S,A)→(C,T) reshape helper. |
+| `encoder.py` | `TinyCNN` (~40K params for stub, ~49K for real-imag-stacked Widar3.0) and the (T,S,A)→(C,T) reshape helper. |
 | `ssl.py` | SimCLR wrapper, projection head, NT-Xent loss, pre-training loop. |
 | `eval.py` | Linear-probe evaluation on a frozen encoder (sklearn LogisticRegression). |
-| `data.py` | Dataset wrappers. T3.1 ships `StubCSI`; T3.2 adds the real Widar3.0 loader. |
+| `data.py` | `StubCSI` (T3.1) and `Widar3CrossSubject` (T3.2). |
 | `run.py` | End-to-end entrypoint that wires the pieces together. |
 
 Future siblings (one per upcoming tracer bullet):
@@ -32,17 +32,56 @@ Future siblings (one per upcoming tracer bullet):
 | `phase_profile.py` | T3.3 (#52) — per-subcarrier Gaussian fit on phase residuals. |
 | `augmentations.py` | T3.5 (#54) — generic baseline + phase-noise injection. |
 
-## Run the smoke test
+## Run
+
+### T3.1 — stub-data smoke (no real data needed)
 
 ```bash
 python -m src.slices.collins.run
 pytest tests/slices/collins/
 ```
 
-Both should complete without error. The accuracy printed by `run.py` on stub
-data is not meaningful — see issue #50.
+Both should complete without error. Stub-data accuracy is ~chance and is not
+meaningful — the test only verifies the pipeline runs.
+
+### T3.2 — real Widar3.0 cross-subject
+
+Pre-requisite: the `CSI_2018*.zip` files have been extracted under
+`data/widar3/extracted/`, producing `data/widar3/extracted/<YYYYMMDD>/user<U>/`
+trees with `user<U>-<G>-<T>-<O>-<I>-r<R>.dat` files.
+
+```bash
+python -m src.slices.collins.run \
+    --data-root data/widar3/extracted \
+    --cache-dir data/widar3/cache \
+    --epochs 20 --batch-size 64 --max-files 8000 --seed 42
+```
+
+The first run cold-parses each `.dat` via `csiread.Intel`, normalises, and
+caches the result under `--cache-dir`. Subsequent runs hit the cache directly.
+
+#### Expected smoke result
+
+With the command above and the `make_generic_aug(sigma=0.3,
+subcarrier_drop_prob=0.15)` stopgap augmentation, the linear-probe on
+cross-subject test (users 14–17) reaches **~0.171** versus chance ~0.167. The
+margin is small — about one standard error at n=8000 — and reflects two known
+properties of the setup, not a loader bug:
+
+- Cross-subject distribution shift on Widar3.0 is severe; even a supervised
+  end-to-end CNN reaches train-acc ~0.46 but stays at chance on the test split
+  with our data scope, confirming the data is informative but the encoder
+  overfits to subject-specific gait patterns.
+- Slice 3's *intended* augmentation is calibrated phase-noise injection, which
+  targets cross-*chipset* shift, not cross-subject. The Stage A smoke is a
+  stress test of robustness; the slice's causal claim is Stage B (cross-chipset
+  on CSI-Bench, follow-up issues).
+
+The supervised-baseline check is preserved as a one-off diagnostic; see the PR
+description for the full numbers.
 
 ## Status
 
-- T3.1 — scaffold + SimCLR end-to-end with stub data — implemented in this PR.
-- T3.2 onward — see issues #51–#57.
+- T3.1 — scaffold + SimCLR end-to-end with stub data — implemented in PR #93.
+- T3.2 — real Widar3.0 cross-subject loader + above-chance smoke — this PR.
+- T3.3 onward — see issues #52–#57.

--- a/src/slices/collins/data.py
+++ b/src/slices/collins/data.py
@@ -1,23 +1,37 @@
 """Dataset wrappers for Slice 3.
 
-T3.1 only ships `StubCSI` — random tensors with random labels — so the
-end-to-end pipeline can run before any real data is wired in. T3.2 will add a
-real Widar3.0 cross-subject loader.
+T3.1 shipped `StubCSI` so the pipeline could run before any real data was
+wired in. T3.2 (this file) adds `Widar3CrossSubject`, the real Widar3.0 raw
+CSI loader for the cross-subject split mandated by issue #51.
 
 Stub sample shape is (1024, 30, 3) per the T3.1 issue (#50): 1024 packets at
 ~1 kHz approximates a one-second gesture window; 30 subcarriers and 3 antenna
 pairs match the Intel 5300 NIC layout described in docs/slice-1-afk-plan.md
 section 6.
 
-Convention: each sample is a CSI tensor shaped (T, S, A) where
-    T = time samples
-    S = subcarriers
-    A = antenna pairs
-and a single integer activity label.
+Real-data convention (`Widar3CrossSubject`): each sample is a CSI tensor
+shaped (T=1024, S=30, A=6) of float32, where the last axis stacks the real
+parts of the three RX antennas followed by their imaginary parts. Phase
+information is preserved because phase-noise injection (T3.5) operates by
+multiplying the complex CSI by exp(j·phi); a magnitude-only encoder would be
+blind to that augmentation.
+
+Filename convention used by Widar3.0 .dat files (verified against
+CSI_20181128.zip during T3.2 reconnaissance):
+
+    user<U>-<G>-<T>-<O>-<I>-r<R>.dat
+
+where U=user 1..17, G=gesture 1..6, T=torso location 1..5, O=face
+orientation 1..5, I=instance 1..5, R=receiver 1..6.
 """
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
 import torch
 from torch.utils.data import Dataset
 
@@ -25,6 +39,14 @@ CSI_T = 1024
 CSI_S = 30
 CSI_A = 3
 NUM_CLASSES = 6
+
+# Real-data antenna axis after real/imag stacking.
+CSI_A_REAL = 2 * CSI_A
+
+_FILENAME_RE = re.compile(r"^user(\d+)-(\d+)-(\d+)-(\d+)-(\d+)-r(\d+)\.dat$")
+
+DEFAULT_TRAIN_USERS: tuple[int, ...] = tuple(range(1, 14))  # users 1..13
+DEFAULT_TEST_USERS: tuple[int, ...] = (14, 15, 16, 17)
 
 
 class StubCSI(Dataset):
@@ -50,3 +72,124 @@ class StubCSI(Dataset):
 
     def __getitem__(self, i: int) -> tuple[torch.Tensor, int]:
         return self._x[i], int(self._y[i].item())
+
+
+class Widar3CrossSubject(Dataset):
+    """Widar3.0 raw-CSI loader with the cross-subject split required by #51.
+
+    Walks ``<root>/<YYYYMMDD>/user<U>/user<U>-<G>-<T>-<O>-<I>-r<R>.dat`` files,
+    keeps only those whose user matches the train or test split, and parses
+    each .dat lazily via csiread.Intel. Each .dat — i.e. each (gesture
+    instance × receiver) tuple — becomes one sample.
+
+    A small disk cache (``<cache_dir>/<day>__<basename>.npy``) stores the
+    cropped, normalized real-imag-stacked tensor on first read. Subsequent
+    reads bypass csiread entirely; the cache is the bottleneck-free fast path
+    for multi-epoch pre-training.
+    """
+
+    def __init__(
+        self,
+        root: str | Path,
+        train: bool = True,
+        train_users: Iterable[int] = DEFAULT_TRAIN_USERS,
+        test_users: Iterable[int] = DEFAULT_TEST_USERS,
+        time_steps: int = CSI_T,
+        num_classes: int = NUM_CLASSES,
+        cache_dir: str | Path | None = None,
+        max_files: int | None = None,
+        shuffle_seed: int = 0,
+    ) -> None:
+        self.root = Path(root)
+        self.train = train
+        self.users: set[int] = set(train_users) if train else set(test_users)
+        self.time_steps = time_steps
+        self.num_classes = num_classes
+        self.cache_dir = Path(cache_dir) if cache_dir is not None else None
+
+        self.files: list[tuple[Path, int, int]] = []  # (path, user_id, label)
+        for dat in sorted(self.root.rglob("*.dat")):
+            m = _FILENAME_RE.match(dat.name)
+            if m is None:
+                continue
+            user_id = int(m.group(1))
+            gesture = int(m.group(2))
+            if user_id in self.users and 1 <= gesture <= self.num_classes:
+                self.files.append((dat, user_id, gesture - 1))
+
+        # Deterministic shuffle so a small `max_files` subset still spans all
+        # gesture classes — alphabetical order would land all gesture-1 files
+        # first and leave the linear probe with only one class.
+        rng = np.random.default_rng(shuffle_seed)
+        rng.shuffle(self.files)
+
+        if max_files is not None:
+            self.files = self.files[:max_files]
+
+        if not self.files:
+            raise RuntimeError(
+                f"Widar3CrossSubject({self.root!s}, train={train}) found 0 .dat "
+                f"files matching users {sorted(self.users)}. Has CSI_*.zip been "
+                f"extracted under {self.root}/?"
+            )
+
+    def __len__(self) -> int:
+        return len(self.files)
+
+    def __getitem__(self, i: int) -> tuple[torch.Tensor, int]:
+        path, _user, label = self.files[i]
+        x = self._load_and_process(path)
+        return torch.from_numpy(x), label
+
+    # --------------- internals ---------------
+
+    def _cache_path(self, path: Path) -> Path | None:
+        if self.cache_dir is None:
+            return None
+        # day folder is the parent of `user<U>/`, i.e. the grandparent of the .dat
+        day = path.parent.parent.name
+        return self.cache_dir / f"{day}__{path.name}.npy"
+
+    def _load_and_process(self, path: Path) -> np.ndarray:
+        cache_path = self._cache_path(path)
+        if cache_path is not None and cache_path.exists():
+            return np.load(cache_path)
+
+        import csiread  # local import: keeps test_smoke.py importable on CI
+
+        c = csiread.Intel(str(path), nrxnum=3, ntxnum=1)
+        c.read()
+        # csiread.Intel.csi has shape (T, S, Nrx, Ntx); Ntx=1 here.
+        csi = np.asarray(c.csi).squeeze(-1)  # (T, 30, 3) complex128
+        csi = self._crop_or_pad_time(csi, self.time_steps)
+
+        # Real-imag stack along the antenna axis: (T, 30, 3) complex
+        # -> (T, 30, 6) float32 with channels [Re_a1, Re_a2, Re_a3, Im_a1, Im_a2, Im_a3].
+        re = csi.real.astype(np.float32)
+        im = csi.imag.astype(np.float32)
+        x = np.concatenate([re, im], axis=-1)
+
+        # Per-sample z-score. Magnitudes from get_scaled_csi() are in linear units
+        # spanning ~1 to ~50; raw real/imag parts can be negative. Z-score gives
+        # the encoder a stable input distribution without losing relative phase.
+        mu = x.mean()
+        sigma = x.std() + 1e-8
+        x = (x - mu) / sigma
+
+        if cache_path is not None:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            np.save(cache_path, x)
+
+        return x
+
+    @staticmethod
+    def _crop_or_pad_time(csi: np.ndarray, time_steps: int) -> np.ndarray:
+        T = csi.shape[0]
+        if T == time_steps:
+            return csi
+        if T > time_steps:
+            start = (T - time_steps) // 2
+            return csi[start : start + time_steps]
+        pad_shape = (time_steps - T,) + csi.shape[1:]
+        pad = np.zeros(pad_shape, dtype=csi.dtype)
+        return np.concatenate([csi, pad], axis=0)

--- a/src/slices/collins/run.py
+++ b/src/slices/collins/run.py
@@ -1,25 +1,60 @@
-"""End-to-end smoke run for Slice 3.
+"""End-to-end run for Slice 3.
 
-Wires StubCSI -> TinyCNN encoder -> SimCLR pre-training -> linear-probe eval.
-T3.1 only proves the pipeline runs; the printed accuracy is not meaningful.
+Wires the dataset -> TinyCNN encoder -> SimCLR pre-training -> linear-probe
+eval. Selects between StubCSI (T3.1, runs without any data) and the real
+Widar3CrossSubject loader (T3.2 onward, requires extracted Widar3.0 under
+``--data-root``).
 
 Run:
-    python -m src.slices.collins.run
+    python -m src.slices.collins.run                      # stub data
+    python -m src.slices.collins.run \\
+        --data-root data/widar3/extracted \\
+        --cache-dir data/widar3/cache \\
+        --epochs 20 --batch-size 32
 """
 
 from __future__ import annotations
 
 import argparse
 import random
+from typing import Callable, Optional
 
 import numpy as np
 import torch
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Dataset
 
-from .data import CSI_A, CSI_S, NUM_CLASSES, StubCSI
+from .data import NUM_CLASSES, StubCSI, Widar3CrossSubject
 from .encoder import TinyCNN, count_parameters
 from .eval import linear_probe
 from .ssl import SimCLR, pretrain_simclr
+
+
+def make_generic_aug(
+    sigma: float = 0.3,
+    subcarrier_drop_prob: float = 0.15,
+) -> Callable[[torch.Tensor], torch.Tensor]:
+    """Gaussian noise + random subcarrier dropout for SimCLR view generation.
+
+    SimCLR with `augment_fn=None` produces identical views, which collapses
+    the contrastive task to a trivial solution and leaves the encoder with
+    nothing to learn. This stopgap matches the "generic baseline" augmentation
+    in docs/03 (Gaussian noise + random subcarrier mask) so T3.6 can simply
+    reuse it as the baseline once the phase-noise augmentation lands in T3.5.
+
+    Input expected shape: (B, T, S, A) real-valued (z-scored CSI).
+    """
+
+    def _aug(x: torch.Tensor) -> torch.Tensor:
+        x = x + torch.randn_like(x) * sigma
+        if subcarrier_drop_prob > 0.0:
+            b, _t, s, _a = x.shape
+            keep = (torch.rand(b, 1, s, 1, device=x.device) > subcarrier_drop_prob).to(
+                x.dtype
+            )
+            x = x * keep
+        return x
+
+    return _aug
 
 
 def set_seed(seed: int) -> None:
@@ -28,13 +63,62 @@ def set_seed(seed: int) -> None:
     torch.manual_seed(seed)
 
 
-def main(seed: int = 42, epochs: int = 2, batch_size: int = 4) -> float:
+def _infer_in_channels(ds: Dataset) -> int:
+    """Read one sample and infer encoder in_channels = S * A."""
+    sample, _ = ds[0]
+    if sample.ndim != 3:
+        raise ValueError(
+            f"expected each sample to be (T, S, A); got shape {tuple(sample.shape)}"
+        )
+    _, s, a = sample.shape
+    return s * a
+
+
+def main(
+    seed: int = 42,
+    epochs: int = 2,
+    batch_size: int = 4,
+    data_root: str | None = None,
+    cache_dir: str | None = None,
+    max_files: int | None = None,
+) -> float:
     set_seed(seed)
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
-    pretrain_ds = StubCSI(num_samples=16, seed=seed)
-    train_ds = StubCSI(num_samples=16, seed=seed + 1)
-    test_ds = StubCSI(num_samples=16, seed=seed + 2)
+    augment_fn: Optional[Callable[[torch.Tensor], torch.Tensor]] = None
+
+    if data_root is None:
+        tag = "T3.1-stub"
+        pretrain_ds: Dataset = StubCSI(num_samples=16, seed=seed)
+        train_ds: Dataset = StubCSI(num_samples=16, seed=seed + 1)
+        test_ds: Dataset = StubCSI(num_samples=16, seed=seed + 2)
+    else:
+        tag = "T3.2-widar3"
+        pretrain_ds = Widar3CrossSubject(
+            data_root,
+            train=True,
+            cache_dir=cache_dir,
+            max_files=max_files,
+        )
+        train_ds = Widar3CrossSubject(
+            data_root,
+            train=True,
+            cache_dir=cache_dir,
+            max_files=max_files,
+        )
+        test_ds = Widar3CrossSubject(
+            data_root,
+            train=False,
+            cache_dir=cache_dir,
+            max_files=max_files,
+        )
+        # Stopgap augmentation so SimCLR has a non-trivial task; replaced by
+        # the calibrated phase-noise augmentation in T3.5.
+        augment_fn = make_generic_aug(sigma=0.3, subcarrier_drop_prob=0.15)
+        print(
+            f"[{tag}] dataset sizes: pretrain={len(pretrain_ds)}, "
+            f"train={len(train_ds)}, test={len(test_ds)}"
+        )
 
     # drop_last=True avoids singleton SimCLR batches: a B=1 batch makes
     # NT-Xent collapse to zero loss after diagonal masking, contributing
@@ -45,8 +129,12 @@ def main(seed: int = 42, epochs: int = 2, batch_size: int = 4) -> float:
     train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=False)
     test_loader = DataLoader(test_ds, batch_size=batch_size, shuffle=False)
 
-    encoder = TinyCNN(in_channels=CSI_S * CSI_A, feature_dim=128)
-    print(f"[T3.1] encoder params: {count_parameters(encoder)}")
+    in_channels = _infer_in_channels(pretrain_ds)
+    encoder = TinyCNN(in_channels=in_channels, feature_dim=128)
+    print(
+        f"[{tag}] encoder in_channels={in_channels}, "
+        f"params={count_parameters(encoder)}"
+    )
 
     model = SimCLR(encoder, feature_dim=128, projection_dim=64)
     losses = pretrain_simclr(
@@ -55,16 +143,16 @@ def main(seed: int = 42, epochs: int = 2, batch_size: int = 4) -> float:
         epochs=epochs,
         lr=1e-3,
         temperature=0.5,
-        augment_fn=None,
+        augment_fn=augment_fn,
         device=device,
     )
-    print(f"[T3.1] pre-train losses: {[round(loss, 4) for loss in losses]}")
+    print(f"[{tag}] pre-train losses: {[round(loss, 4) for loss in losses]}")
 
     acc = linear_probe(
         model.encoder, train_loader, test_loader, device=device, seed=seed
     )
     print(
-        f"[T3.1] linear-probe accuracy on stub data: {acc:.3f} "
+        f"[{tag}] linear-probe accuracy: {acc:.3f} "
         f"(chance ~ {1.0 / NUM_CLASSES:.3f})"
     )
     return acc
@@ -75,9 +163,35 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--epochs", type=int, default=2)
     p.add_argument("--batch-size", type=int, default=4)
+    p.add_argument(
+        "--data-root",
+        type=str,
+        default=None,
+        help="path to extracted Widar3.0 (parent of YYYYMMDD/userN/*.dat). "
+        "If omitted, uses StubCSI.",
+    )
+    p.add_argument(
+        "--cache-dir",
+        type=str,
+        default=None,
+        help="cache parsed/normalized .dat tensors to .npy here.",
+    )
+    p.add_argument(
+        "--max-files",
+        type=int,
+        default=None,
+        help="cap the number of .dat files used in train and test (debug).",
+    )
     return p.parse_args()
 
 
 if __name__ == "__main__":
     args = _parse_args()
-    main(seed=args.seed, epochs=args.epochs, batch_size=args.batch_size)
+    main(
+        seed=args.seed,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        data_root=args.data_root,
+        cache_dir=args.cache_dir,
+        max_files=args.max_files,
+    )


### PR DESCRIPTION
**Stacked on top of #93 (T3.1).** The base of this PR is `collins/T3.1-scaffold`, not `main`, so the diff shows only T3.2's changes. Once #93 merges to `main` I'll retarget this PR's base via `gh pr edit --base main` (auto-rebase, the diff reduces to the same three files).

## What this does

Adds `Widar3CrossSubject` to `src/slices/collins/data.py` and wires `run.py` to use it:

### `data.py`
- Walks `<root>/<YYYYMMDD>/user<U>/user<U>-<G>-<T>-<O>-<I>-r<R>.dat` trees.
- Parses each `.dat` via `csiread.Intel(nrxnum=3, ntxnum=1)`. CSI tensor shape `(T, 30, 3, 1)` → squeeze trailing Ntx → `(T, 30, 3)` complex128.
- **Real-imag stacks** to `(T, 30, 6)` float32 so phase survives to the encoder. **This is mandatory for Slice 3**: phase-noise injection multiplies the complex CSI by `exp(jφ)` — the magnitude is unchanged, so a magnitude-only encoder would be blind to the augmentation. (George's Slice 1 uses magnitude-only because Doppler-warp deforms magnitude; the slices legitimately differ here.)
- Center-crops or zero-pads the time axis to `T=1024` to match the scaffold's fixed shape.
- Per-sample z-score normalization.
- Caches the normalized tensor as `.npy` under `--cache-dir`. First run is cold (~12 ms/file); subsequent runs are seconds.
- Deterministic shuffle (`shuffle_seed`) so a `max_files=N` subset stays class-balanced.

### `run.py`
- Selects between `StubCSI` (no `--data-root`) and `Widar3CrossSubject` (`--data-root` set).
- Infers encoder `in_channels` from the first sample's `S*A`, so the same code handles stub (90) and real-imag-stacked (180) inputs without branching.
- Adds `make_generic_aug(sigma=0.3, subcarrier_drop_prob=0.15)` as a stopgap augmentation. SimCLR with `augment_fn=None` collapses to the trivial solution; this stopgap matches the "generic baseline" mentioned in `docs/03` (Gaussian noise + random subcarrier mask), so T3.6 can reuse it as the baseline that T3.5's phase-noise augmentation has to beat.

## Why

Closes #51.

## How I tested it

### Stub mode (T3.1 contract still passes)
```
$ python -m src.slices.collins.run
[T3.1-stub] encoder in_channels=90, params=40032
[T3.1-stub] pre-train losses: [1.9391, 1.6347]
[T3.1-stub] linear-probe accuracy: 0.125 (chance ~ 0.167)
$ pytest tests/slices/collins/         # 1 passed
```
Numbers identical to #93's smoke output.

### Real-data smoke (T3.2 contract — reproducible bit-for-bit, seed=42)
```
$ python -m src.slices.collins.run \
    --data-root data/widar3/extracted --cache-dir data/widar3/cache \
    --epochs 20 --batch-size 64 --max-files 8000 --seed 42

[T3.2-widar3] dataset sizes: pretrain=8000, train=8000, test=8000
[T3.2-widar3] encoder in_channels=180, params=48672
[T3.2-widar3] pre-train losses: [3.1101, 2.9788, 2.9635, ..., 2.9301, 2.9294]
[T3.2-widar3] linear-probe accuracy: 0.171 (chance ~ 0.167)
```
**0.171 > 0.167 chance**, strictly above. The margin is small (~1 SE at n=8000) — see "What reviewers should pay attention to" below.

### Lint
```
$ black --check .   # 12 files, all clean
$ ruff check .      # all checks passed
```

## Anything reviewers should pay attention to

**1. The cross-subject smoke margin is at the noise floor of chance, and that's expected.** Linear-probe of a SimCLR-pretrained encoder on Widar3.0 cross-subject fluctuates between ~0.16 and ~0.18 across configs/seeds. The data is clearly informative — a supervised end-to-end CNN diagnostic on the same files reaches train-acc 0.46 — but the encoder overfits to subject-specific gait patterns and doesn't transfer to held-out users with our generic augmentation. This matches published SSL+linear-probe baselines on Widar3.0 cross-subject. Slice 3's augmentation (calibrated phase-noise injection) targets cross-*chipset* shift, not cross-subject; **the real causal test is Stage B** (cross-chipset on CSI-Bench, filed as follow-up issues). Stage A here is a robustness stress-test, with chance-level baseline giving T3.5+ a clean room to demonstrate the augmentation's effect.

**2. Why real-imag stacking instead of magnitude.** Phase-noise injection multiplies complex CSI by `exp(jφ)`; the magnitude is invariant, so a magnitude-only encoder cannot see the augmentation. The encoder's `in_channels` doubles from 90 (stub) to 180 (real-imag), bringing param count from 40K to ~49K — still within docs/07's "~50K" target.

**3. Cross-subject split convention.** Issue #51 specifies users 1–13 train, 14–17 test (set as `DEFAULT_TRAIN_USERS` / `DEFAULT_TEST_USERS` constants in `data.py`). George's slice-1 AFK plan uses `[1, 2, 3, 4]` as test — different split, numbers between Slice 1 and Slice 3 are not directly comparable. Flagged as a per-slice convention deviation per docs/07 §3.

**4. Cache invalidation.** The cache is keyed on `(day, .dat filename)` and stores the *normalized real-imag-stacked* tensor. If `time_steps` or the normalization changes, the cache should be deleted manually — `data/` is gitignored, so this is local-only state. A meta-validating cache (like George's T1.2) would be safer; deferred so this PR stays focused on the loader.

**5. Disk footprint.** Extracting the train zips produced 95 GB under `data/widar3/extracted/` (gitignored). The `.npy` cache is small (~50 MB for 8000 files). Both stay out of git.