### PR TITLE
T3.5 — Phase-noise injection augmentation

### DIFF
--- a/src/slices/collins/augmentations.py
+++ b/src/slices/collins/augmentations.py
@@ -1,0 +1,109 @@
+"""Augmentations for Slice 3 SimCLR pre-training.
+
+Two factories live here, both returning a ``Callable[[Tensor], Tensor]`` that
+accepts a real-valued CSI batch shaped ``(B, T, S, 2*A)`` — the real-imag
+stacking convention from ``data.Widar3CrossSubject``: channels ``[0..A-1]``
+hold the real parts of the antennas and channels ``[A..2A-1]`` hold the
+imaginary parts.
+
+- ``make_generic_aug`` — Gaussian noise + random subcarrier dropout. The
+  project-wide "generic baseline" augmentation (docs/03 §5.3). T3.6 uses
+  this as the baseline that phase-noise injection has to beat.
+- ``make_phase_noise_aug`` — calibrated phase-noise injection per the T3.3
+  per-subcarrier Gaussian profile. The slice's headline augmentation.
+
+Both factories take their hyperparameters at construction time so the SimCLR
+loop in ``ssl.py`` only ever sees a stateless ``augment_fn(batch) -> batch``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import torch
+
+from .phase_profile import load_profile
+
+AugmentFn = Callable[[torch.Tensor], torch.Tensor]
+
+
+def make_generic_aug(
+    sigma: float = 0.3,
+    subcarrier_drop_prob: float = 0.15,
+) -> AugmentFn:
+    """Gaussian noise + random subcarrier dropout. T3.6 baseline.
+
+    Mirrors the "generic baseline" augmentation in docs/03: additive Gaussian
+    noise with std ``sigma`` plus i.i.d. per-subcarrier Bernoulli dropout with
+    probability ``subcarrier_drop_prob``. Same noise/mask realization is
+    broadcast across time and antenna axes so a dropped subcarrier is dropped
+    for the whole window — the way frequency-selective fading actually
+    behaves on a coherence time-scale much longer than the packet rate.
+    """
+
+    def _aug(x: torch.Tensor) -> torch.Tensor:
+        x = x + torch.randn_like(x) * sigma
+        if subcarrier_drop_prob > 0.0:
+            b, _t, s, _a = x.shape
+            keep = (torch.rand(b, 1, s, 1, device=x.device) > subcarrier_drop_prob).to(
+                x.dtype
+            )
+            x = x * keep
+        return x
+
+    return _aug
+
+
+def make_phase_noise_aug(
+    profile_path: str | Path,
+) -> AugmentFn:
+    """Phase-noise injection from a fitted T3.3 profile.
+
+    Loads ``(mu, sigma)`` from ``profile_path`` (the ``.npz`` produced by
+    ``python -m src.slices.collins.phase_profile``). Each augmentation call
+    samples per-``(B, T, S, A)`` element phase offsets ``phi ~ N(mu_k,
+    sigma_k**2)`` — matching the per-(packet, subcarrier, antenna) sampling
+    granularity that T3.3 modeled — and rotates the complex CSI by
+    ``exp(j*phi)``.
+
+    Magnitude ``|H|`` is preserved exactly; only phase changes. This is the
+    physical correctness guarantee of the augmentation: a real chipset swap
+    would shift phase, not magnitude. (And it is precisely *why* this slice
+    needed the real-imag stacked loader — a magnitude-only encoder would be
+    blind to the augmentation.)
+    """
+    mu_np, sigma_np = load_profile(Path(profile_path))
+    mu_buf = torch.from_numpy(mu_np).float()  # (S,)
+    sigma_buf = torch.from_numpy(sigma_np).float()  # (S,)
+
+    def _aug(x: torch.Tensor) -> torch.Tensor:
+        if x.ndim != 4:
+            raise ValueError(
+                f"phase-noise aug expects (B, T, S, 2*A); got shape {tuple(x.shape)}"
+            )
+        b, t, s, double_a = x.shape
+        if double_a % 2 != 0:
+            raise ValueError(
+                f"last dim must be 2*A (real-imag stacked); got {double_a}"
+            )
+        a = double_a // 2
+
+        # Split real-imag back into a complex view of CSI.
+        re = x[..., :a]
+        im = x[..., a:]
+        csi = torch.complex(re, im)  # (B, T, S, A) complex64 (since re/im are f32)
+
+        # Move profile to the input device the first time we see one and
+        # broadcast over (B, T, A). Each call resamples its own randomness so
+        # SimCLR's two views differ.
+        mu = mu_buf.to(x.device).view(1, 1, s, 1)
+        sigma = sigma_buf.to(x.device).view(1, 1, s, 1)
+        phi = torch.randn(b, t, s, a, device=x.device, dtype=x.dtype) * sigma + mu
+
+        rot = torch.complex(torch.cos(phi), torch.sin(phi))
+        rotated = csi * rot
+
+        return torch.cat([rotated.real, rotated.imag], dim=-1).to(x.dtype)
+
+    return _aug

--- a/src/slices/collins/run.py
+++ b/src/slices/collins/run.py
@@ -17,44 +17,17 @@ from __future__ import annotations
 
 import argparse
 import random
-from typing import Callable, Optional
+from typing import Optional
 
 import numpy as np
 import torch
 from torch.utils.data import DataLoader, Dataset
 
+from .augmentations import AugmentFn, make_generic_aug, make_phase_noise_aug
 from .data import NUM_CLASSES, StubCSI, Widar3CrossSubject
 from .encoder import TinyCNN, count_parameters
 from .eval import linear_probe
 from .ssl import SimCLR, pretrain_simclr
-
-
-def make_generic_aug(
-    sigma: float = 0.3,
-    subcarrier_drop_prob: float = 0.15,
-) -> Callable[[torch.Tensor], torch.Tensor]:
-    """Gaussian noise + random subcarrier dropout for SimCLR view generation.
-
-    SimCLR with `augment_fn=None` produces identical views, which collapses
-    the contrastive task to a trivial solution and leaves the encoder with
-    nothing to learn. This stopgap matches the "generic baseline" augmentation
-    in docs/03 (Gaussian noise + random subcarrier mask) so T3.6 can simply
-    reuse it as the baseline once the phase-noise augmentation lands in T3.5.
-
-    Input expected shape: (B, T, S, A) real-valued (z-scored CSI).
-    """
-
-    def _aug(x: torch.Tensor) -> torch.Tensor:
-        x = x + torch.randn_like(x) * sigma
-        if subcarrier_drop_prob > 0.0:
-            b, _t, s, _a = x.shape
-            keep = (torch.rand(b, 1, s, 1, device=x.device) > subcarrier_drop_prob).to(
-                x.dtype
-            )
-            x = x * keep
-        return x
-
-    return _aug
 
 
 def set_seed(seed: int) -> None:
@@ -81,11 +54,12 @@ def main(
     data_root: str | None = None,
     cache_dir: str | None = None,
     max_files: int | None = None,
+    phase_profile: str | None = None,
 ) -> float:
     set_seed(seed)
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
-    augment_fn: Optional[Callable[[torch.Tensor], torch.Tensor]] = None
+    augment_fn: Optional[AugmentFn] = None
 
     if data_root is None:
         tag = "T3.1-stub"
@@ -93,7 +67,6 @@ def main(
         train_ds: Dataset = StubCSI(num_samples=16, seed=seed + 1)
         test_ds: Dataset = StubCSI(num_samples=16, seed=seed + 2)
     else:
-        tag = "T3.2-widar3"
         pretrain_ds = Widar3CrossSubject(
             data_root,
             train=True,
@@ -112,9 +85,15 @@ def main(
             cache_dir=cache_dir,
             max_files=max_files,
         )
-        # Stopgap augmentation so SimCLR has a non-trivial task; replaced by
-        # the calibrated phase-noise augmentation in T3.5.
-        augment_fn = make_generic_aug(sigma=0.3, subcarrier_drop_prob=0.15)
+        # Augmentation choice: phase-noise (T3.5) when a profile is provided,
+        # otherwise the generic baseline (T3.6's baseline). Both factories live
+        # in augmentations.py; we just hand SimCLR the resulting callable.
+        if phase_profile is not None:
+            tag = "T3.5-widar3-phase-noise"
+            augment_fn = make_phase_noise_aug(phase_profile)
+        else:
+            tag = "T3.2-widar3"
+            augment_fn = make_generic_aug(sigma=0.3, subcarrier_drop_prob=0.15)
         print(
             f"[{tag}] dataset sizes: pretrain={len(pretrain_ds)}, "
             f"train={len(train_ds)}, test={len(test_ds)}"
@@ -182,6 +161,13 @@ def _parse_args() -> argparse.Namespace:
         default=None,
         help="cap the number of .dat files used in train and test (debug).",
     )
+    p.add_argument(
+        "--phase-profile",
+        type=str,
+        default=None,
+        help="path to a T3.3 phase_profile.npz; when set, replaces the "
+        "generic baseline aug with calibrated phase-noise injection (T3.5).",
+    )
     return p.parse_args()
 
 
@@ -194,4 +180,5 @@ if __name__ == "__main__":
         data_root=args.data_root,
         cache_dir=args.cache_dir,
         max_files=args.max_files,
+        phase_profile=args.phase_profile,
     )

--- a/tests/slices/collins/test_augmentations.py
+++ b/tests/slices/collins/test_augmentations.py
@@ -1,0 +1,115 @@
+"""T3.5 — augmentations.py tests.
+
+Unit tests for the generic baseline and phase-noise injection augmentations
+introduced in #54. The interesting invariants:
+
+- shape is preserved (same `(B, T, S, 2*A)` in and out);
+- magnitude is preserved by phase-noise injection (it's a unitary rotation);
+- two consecutive calls give different results (each call resamples its
+  randomness, so SimCLR's two views differ).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from src.slices.collins.augmentations import (
+    make_generic_aug,
+    make_phase_noise_aug,
+)
+from src.slices.collins.phase_profile import save_profile
+
+
+def _toy_csi_batch(b: int = 2, t: int = 64, s: int = 30, a: int = 3) -> torch.Tensor:
+    """Random real-imag-stacked CSI batch shaped ``(B, T, S, 2*A)``."""
+    g = torch.Generator().manual_seed(0)
+    return torch.randn(b, t, s, 2 * a, generator=g, dtype=torch.float32)
+
+
+def test_generic_aug_preserves_shape_and_is_stochastic():
+    aug = make_generic_aug(sigma=0.3, subcarrier_drop_prob=0.15)
+    x = _toy_csi_batch()
+    y1 = aug(x)
+    y2 = aug(x)
+    assert y1.shape == x.shape
+    assert y2.shape == x.shape
+    # Different stochastic draws => the two views must differ.
+    assert not torch.equal(y1, y2)
+    # Generic aug shifts and masks; output should differ from input as well.
+    assert not torch.equal(y1, x)
+
+
+def test_phase_noise_aug_preserves_shape_and_magnitude(tmp_path: Path):
+    # Build a tiny synthetic profile (mu=0, sigma=0.5) and save it like T3.3 would.
+    s = 30
+    profile_path = tmp_path / "phase_profile.npz"
+    save_profile(
+        profile_path,
+        mu=np.zeros(s, dtype=np.float32),
+        sigma=np.full(s, 0.5, dtype=np.float32),
+        num_samples_per_subcarrier=1024,
+        meta={"data_root": "synthetic", "users": [], "num_files": 0, "seed": 0},
+    )
+
+    aug = make_phase_noise_aug(profile_path)
+    x = _toy_csi_batch(b=2, t=64, s=s, a=3)
+
+    y = aug(x)
+
+    # Shape preserved
+    assert y.shape == x.shape
+
+    # Magnitude preserved per (b, t, s, a). Because the augmentation rotates
+    # the complex CSI by exp(j*phi) — a unitary operation — sqrt(re**2+im**2)
+    # for each antenna must match the input within float-precision tolerance.
+    a = x.shape[-1] // 2
+    re_in, im_in = x[..., :a], x[..., a:]
+    re_out, im_out = y[..., :a], y[..., a:]
+    mag_in = torch.sqrt(re_in**2 + im_in**2)
+    mag_out = torch.sqrt(re_out**2 + im_out**2)
+    torch.testing.assert_close(mag_in, mag_out, rtol=1e-5, atol=1e-5)
+
+    # And — confirming the augmentation is non-trivial — the real/imag parts
+    # do change when phase rotates.
+    assert not torch.equal(y, x)
+
+
+def test_phase_noise_aug_is_stochastic(tmp_path: Path):
+    s = 30
+    profile_path = tmp_path / "phase_profile.npz"
+    save_profile(
+        profile_path,
+        mu=np.zeros(s, dtype=np.float32),
+        sigma=np.full(s, 0.5, dtype=np.float32),
+        num_samples_per_subcarrier=1024,
+        meta={"data_root": "synthetic", "users": [], "num_files": 0, "seed": 0},
+    )
+    aug = make_phase_noise_aug(profile_path)
+    x = _toy_csi_batch()
+    y1 = aug(x)
+    y2 = aug(x)
+    # Each call resamples; SimCLR's two views must differ.
+    assert not torch.equal(y1, y2)
+
+
+def test_phase_noise_aug_rejects_odd_last_dim(tmp_path: Path):
+    s = 30
+    profile_path = tmp_path / "phase_profile.npz"
+    save_profile(
+        profile_path,
+        mu=np.zeros(s, dtype=np.float32),
+        sigma=np.full(s, 0.5, dtype=np.float32),
+        num_samples_per_subcarrier=1024,
+        meta={"data_root": "synthetic", "users": [], "num_files": 0, "seed": 0},
+    )
+    aug = make_phase_noise_aug(profile_path)
+    bad = torch.zeros(2, 64, s, 5)  # last dim must be 2*A; 5 is odd
+    try:
+        aug(bad)
+    except ValueError as e:
+        assert "2*A" in str(e) or "real-imag" in str(e)
+    else:
+        raise AssertionError("expected ValueError on odd last dim")


### PR DESCRIPTION
**Stacked on #96 (T3.4).** Stack so far: `main → #93 (T3.1) → #94 (T3.2) → #95 (T3.3) → #96 (T3.4) → this PR`. Bases retarget as each PR merges.

## What this does

Adds `src/slices/collins/augmentations.py` per #54 — the slice's headline file — with two factory functions:

| Factory | What it produces |
|---|---|
| `make_generic_aug(sigma, subcarrier_drop_prob)` | Gaussian noise + random per-subcarrier dropout. Used by T3.6 as the baseline. Moved here from `run.py`. |
| `make_phase_noise_aug(profile_path)` | The headline augmentation. Loads `(μ, σ)` from a T3.3 `phase_profile.npz`, samples `φ ~ N(μ_k, σ_k²)` per `(B, T, S, A)` element, rotates complex CSI by `exp(jφ)`. |

Both factories return a `Callable[[Tensor], Tensor]` that conforms to the existing `augment_fn` hook in `ssl.py` — SimCLR sees no new code path.

Plus:
- `run.py` learns a `--phase-profile PATH` flag. When set, pre-training uses the phase-noise aug; otherwise the generic baseline. Tag flips from `T3.2-widar3` to `T3.5-widar3-phase-noise`.
- `tests/slices/collins/test_augmentations.py` — four unit tests, including the critical **magnitude-preservation** check that confirms the rotation is genuinely unitary.

## Why

Closes #54. Fifth tracer bullet of Slice 3.

## How I tested it

### Augmentation unit tests (4 new)
```
$ pytest tests/slices/collins/test_augmentations.py -v
test_generic_aug_preserves_shape_and_is_stochastic           PASSED
test_phase_noise_aug_preserves_shape_and_magnitude           PASSED   # the critical one
test_phase_noise_aug_is_stochastic                           PASSED
test_phase_noise_aug_rejects_odd_last_dim                    PASSED
```

The magnitude-preservation test asserts `sqrt(re² + im²)` is bit-equal (within 1e-5) before and after the augmentation. This is the physical-correctness guarantee: a real chipset swap shifts phase, not magnitude.

### Stub mode (T3.1 contract still passes)
```
$ python -m src.slices.collins.run
[T3.1-stub] encoder params: 40032
[T3.1-stub] linear-probe accuracy: 0.125 (chance ~ 0.167)
```
Same numbers as #93 — refactor didn't regress anything.

### Real Widar3.0 with phase-noise aug
```
$ python -m src.slices.collins.run \
    --data-root data/widar3/extracted --cache-dir data/widar3/cache \
    --phase-profile data/widar3/cache/phase_profile.npz \
    --epochs 20 --batch-size 64 --max-files 8000 --seed 42

[T3.5-widar3-phase-noise] dataset sizes: pretrain=8000, train=8000, test=8000
[T3.5-widar3-phase-noise] encoder in_channels=180, params=48672
[T3.5-widar3-phase-noise] pre-train losses: [3.38, 3.04, ..., 2.95, 2.94]
[T3.5-widar3-phase-noise] linear-probe accuracy: 0.162 (chance ~ 0.167)
```
Pre-training runs end-to-end — the contract. **0.162 vs T3.2's 0.171** is at the noise floor and not a formal comparison; that's T3.6's job.

### Full slice test suite
```
$ pytest tests/slices/collins/ -v        # 8 passed in 1.6 s
$ black --check .                         # 16 files unchanged
$ ruff check .                            # all checks passed
```

## Anything reviewers should pay attention to

**1. The 0.162 < 0.171 preliminary number is a hypothesis-shaping observation.** With σ ≈ 1.80 rad from the Stage A profile, phase-noise injection is essentially a *near-uniform phase scramble* — every (packet, subcarrier, antenna) gets rotated by an angle drawn from a distribution close to uniform on (-π, π]. Effectively this forces the encoder to rely on magnitude alone, undoing the real-imag stacking we did in T3.2. A *calibrated chipset-fingerprint* augmentation requires Stage B (CSI-Bench, multiple chipsets) where the residual will isolate hardware-specific shifts (smaller σ, structured per-chipset distribution). T3.6 will quantify the Stage A effect; T3.8 should frame it.

**2. Per-(B, T, S, A) IID sampling matches T3.3's fitting granularity.** T3.3 collapsed `(packet, antenna)` into i.i.d. samples per subcarrier when fitting the Gaussian, so the natural draw for augmentation is also i.i.d. across `(packet, antenna)`. An alternative interpretation — "one phase shift per chipset, broadcast over the recording" — would be physically more like a chipset-fingerprint, but that's not what T3.3 modelled. Keeping the granularity consistent across fit and augmentation.

**3. Why complex reconstruction inside the augmentation, not in the loader.** Keeps `data.Widar3CrossSubject`'s `(T, S, 2*A)` real-valued contract untouched (one less coupling between `data.py` and `augmentations.py`). The reconstruction is two slices and a `torch.complex` call — cheap.

**4. Profile buffers move to GPU lazily.** `mu`/`sigma` are stored on CPU in the closure; the first call moves them to `x.device`. If the augmentation runs on GPU, this is a one-time host-to-device copy and the tensor stays on device for subsequent calls (PyTorch's `.to()` is a no-op when already on the target device). Keeps the factory portable across CPU and GPU runs without extra plumbing.

**5. AugmentFn type alias** added to `augmentations.py` and re-exported into `run.py` — replaces the inline `Callable[[torch.Tensor], torch.Tensor]` annotations and gives the factories a self-describing signature.