### PR TITLE
T1.4 + T1.5 — Doppler-aware time warping augmentation + sanity test (re-opened after #86)

### DIFF
--- a/src/slices/george/augmentations.py
+++ b/src/slices/george/augmentations.py
@@ -1,0 +1,78 @@
+"""CSI augmentations for SimCLR view-pair generation.
+
+T1.4 ships `doppler_warp` — a physics-informed time-axis stretch by a random
+factor in [0.7, 1.4]. The intuition: activity speed scales the Doppler
+component of CSI approximately linearly, so warping the time axis simulates
+the same activity performed at a different speed and forces the encoder
+to learn speed-invariant features.
+
+The function operates on float-real CSI shaped (T, S, A) for a single sample
+or (B, T, S, A) for a batch. T1.2 will decide how to project complex
+Widar3.0 CSI into a real tensor (magnitude / real+imag stack); the
+augmentation accepts whatever real-valued shape lands.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+DEFAULT_FACTOR_RANGE = (0.7, 1.4)
+
+
+def _sample_factor(low: float = 0.7, high: float = 1.4) -> float:
+    return float(torch.empty(1).uniform_(low, high).item())
+
+
+def _doppler_warp_one(x: torch.Tensor, factor: float) -> torch.Tensor:
+    """Stretch a single CSI sample's time axis by `factor`, then crop or
+    zero-pad back to the original length.
+
+    Cropping (rather than re-resampling to T) preserves the *frequency*
+    content of the warped signal: a factor>1 stretch shifts the dominant
+    frequency *down* in the cropped result; a factor<1 squeeze shifts it
+    *up*. T1.5's sanity test exercises this property.
+    """
+    if x.ndim != 3:
+        raise ValueError(f"_doppler_warp_one expects (T, S, A); got {tuple(x.shape)}")
+    t, s, a = x.shape
+    t_new = max(1, int(round(t * factor)))
+
+    # F.interpolate with mode='linear' wants (N, C, L). Treat S*A as channels,
+    # T as the spatial axis.
+    x_in = x.permute(1, 2, 0).reshape(1, s * a, t)
+    x_r = F.interpolate(x_in, size=t_new, mode="linear", align_corners=False)
+    x_r = x_r.reshape(s, a, t_new).permute(2, 0, 1)
+
+    if x_r.shape[0] >= t:
+        return x_r[:t]
+    pad = torch.zeros(t - x_r.shape[0], s, a, dtype=x.dtype, device=x.device)
+    return torch.cat([x_r, pad], dim=0)
+
+
+def doppler_warp(
+    x: torch.Tensor,
+    factor: float | None = None,
+    factor_range: tuple[float, float] = DEFAULT_FACTOR_RANGE,
+) -> torch.Tensor:
+    """Apply Doppler-aware time warping to a CSI tensor.
+
+    Accepts a single sample shaped `(T, S, A)` or a batch shaped
+    `(B, T, S, A)`. If `factor` is None, each sample gets an independently
+    sampled factor from `factor_range` — that's what makes this useful as a
+    SimCLR view-pair augmentation: two calls produce two views that differ
+    in their Doppler stretch.
+    """
+    low, high = factor_range
+    if x.ndim == 3:
+        f = _sample_factor(low, high) if factor is None else factor
+        return _doppler_warp_one(x, f)
+    if x.ndim == 4:
+        out = torch.empty_like(x)
+        for i in range(x.shape[0]):
+            f = _sample_factor(low, high) if factor is None else factor
+            out[i] = _doppler_warp_one(x[i], f)
+        return out
+    raise ValueError(
+        f"doppler_warp expects (T, S, A) or (B, T, S, A); got {tuple(x.shape)}"
+    )

--- a/src/slices/george/run.py
+++ b/src/slices/george/run.py
@@ -16,10 +16,16 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
+from .augmentations import doppler_warp
 from .data import CSI_A, CSI_S, NUM_CLASSES, StubCSI
 from .encoder import TinyCNN, count_parameters
 from .eval import linear_probe
 from .ssl import SimCLR, pretrain_simclr
+
+AUGMENTATIONS = {
+    "none": None,
+    "doppler": doppler_warp,
+}
 
 
 def set_seed(seed: int) -> None:
@@ -28,7 +34,16 @@ def set_seed(seed: int) -> None:
     torch.manual_seed(seed)
 
 
-def main(seed: int = 42, epochs: int = 2, batch_size: int = 4) -> float:
+def main(
+    seed: int = 42,
+    epochs: int = 2,
+    batch_size: int = 4,
+    aug: str = "none",
+) -> float:
+    if aug not in AUGMENTATIONS:
+        raise ValueError(
+            f"unknown augmentation {aug!r}; pick from {sorted(AUGMENTATIONS)}"
+        )
     set_seed(seed)
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -49,16 +64,17 @@ def main(seed: int = 42, epochs: int = 2, batch_size: int = 4) -> float:
     print(f"[T1.1] encoder params: {count_parameters(encoder)}")
 
     model = SimCLR(encoder, feature_dim=128, projection_dim=64)
+    augment_fn = AUGMENTATIONS[aug]
     losses = pretrain_simclr(
         model,
         pretrain_loader,
         epochs=epochs,
         lr=1e-3,
         temperature=0.5,
-        augment_fn=None,
+        augment_fn=augment_fn,
         device=device,
     )
-    print(f"[T1.1] pre-train losses: {[round(loss, 4) for loss in losses]}")
+    print(f"[T1.1] aug={aug!r} pre-train losses: {[round(loss, 4) for loss in losses]}")
 
     acc = linear_probe(
         model.encoder, train_loader, test_loader, device=device, seed=seed
@@ -74,9 +90,15 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--epochs", type=int, default=2)
     p.add_argument("--batch-size", type=int, default=4)
+    p.add_argument("--aug", choices=sorted(AUGMENTATIONS), default="none")
     return p.parse_args()
 
 
 if __name__ == "__main__":
     args = _parse_args()
-    main(seed=args.seed, epochs=args.epochs, batch_size=args.batch_size)
+    main(
+        seed=args.seed,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        aug=args.aug,
+    )

--- a/tests/slices/george/test_doppler.py
+++ b/tests/slices/george/test_doppler.py
@@ -1,0 +1,50 @@
+"""T1.5 sanity test for `doppler_warp`.
+
+A pure-tone CSI of frequency f0 stretched by factor 2.0 (then re-cropped to
+the original window length) should expose the *first half* of the stretched
+signal — half a wavelength's worth of cycles — so its dominant frequency in
+the cropped FFT lands near f0/2.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from src.slices.george.augmentations import doppler_warp
+
+
+def test_doppler_factor_two_halves_dominant_frequency():
+    t_steps = 256
+    f0_cycles = 8.0  # cycles over the 256-sample window
+
+    t = torch.linspace(0, 1, t_steps)
+    x = torch.sin(2 * math.pi * f0_cycles * t).reshape(t_steps, 1, 1)
+
+    y = doppler_warp(x, factor=2.0)
+
+    fft_x = torch.fft.rfft(x[:, 0, 0]).abs()
+    fft_y = torch.fft.rfft(y[:, 0, 0]).abs()
+    peak_x = int(fft_x.argmax())
+    peak_y = int(fft_y.argmax())
+
+    assert peak_x == int(
+        round(f0_cycles)
+    ), f"input dominant bin should be {int(round(f0_cycles))}, got {peak_x}"
+    assert abs(peak_y - peak_x // 2) <= 2, (
+        f"after factor=2.0 stretch+crop, dominant frequency should "
+        f"be near {peak_x // 2}, got {peak_y}"
+    )
+
+
+def test_doppler_random_factor_preserves_shape():
+    sample = torch.randn(100, 30, 3)
+    out = doppler_warp(sample)
+    assert out.shape == sample.shape
+
+
+def test_doppler_batched_independent_factors():
+    batch = torch.randn(4, 100, 30, 3)
+    out = doppler_warp(batch)
+    assert out.shape == batch.shape


### PR DESCRIPTION
Re-opens PR #86 which auto-closed during the post-#82 cleanup cascade. Rebased onto current main (which now has T1.1 #83 and T1.2 #108).