### PR TITLE
T5.2 — Slice 5 real Widar3.0 cross-subject loader

### DIFF
--- a/src/slices/josiah/data.py
+++ b/src/slices/josiah/data.py
@@ -1,17 +1,28 @@
 """Dataset wrappers for Slice 5 (baseline reproduction).
 
-T5.1 ships `StubCSI` for end-to-end pipeline plumbing on random tensors —
-same shape convention as Slice 1 so encoder code transfers directly. T5.2
-will add the real Widar3.0 cross-subject loader.
+T5.1 ships `StubCSI` for end-to-end pipeline plumbing on random tensors.
+T5.2 adds `Widar3CrossSubject` — the real Widar3.0 cross-subject loader,
+ported from Slice 1's loader per the slice-independence convention in
+`docs/08-team-work-plan.md` section 2.
 
 Convention: each sample is a real-valued CSI tensor shaped `(T, S, A)` where
-    T = time samples
+    T = time samples (per-instance variable; cropped/padded to a fixed length)
     S = subcarriers (30 for Intel 5300)
     A = antenna pairs (3 for the typical Widar3.0 1-TX × 3-RX setup)
 plus a single integer gesture label in `[0, NUM_CLASSES)`.
+
+The Widar3.0 raw release ships `.dat` files in the Linux 802.11n CSI Tool
+format (Halperin et al.). We use `csiread.Intel` for parsing; complex CSI
+is reduced to its magnitude as the real-valued projection consumed by the
+encoder. T5.2 keeps the same projection as Slice 1 so the comparison row
+in the team's results figure is apples-to-apples (same preprocessing,
+different training objective).
 """
 
 from __future__ import annotations
+
+import re
+from pathlib import Path
 
 import torch
 from torch.utils.data import Dataset
@@ -23,10 +34,7 @@ NUM_CLASSES = 6
 
 
 class StubCSI(Dataset):
-    """Random CSI samples — pipeline plumbing only, no real signal.
-
-    Identical interface to Slice 1's `StubCSI` so the scaffold ports cleanly.
-    """
+    """Random CSI samples — pipeline plumbing only, no real signal."""
 
     def __init__(
         self,
@@ -42,6 +50,189 @@ class StubCSI(Dataset):
             num_samples, time_steps, subcarriers, antenna_pairs, generator=g
         )
         self._y = torch.randint(0, num_classes, (num_samples,), generator=g)
+
+    def __len__(self) -> int:
+        return self._x.shape[0]
+
+    def __getitem__(self, i: int) -> tuple[torch.Tensor, int]:
+        return self._x[i], int(self._y[i].item())
+
+
+# ---------------------------------------------------------------------------
+# Widar3.0 cross-subject loader (T5.2)
+
+WIDAR3_FILENAME_RE = re.compile(
+    r"^user(?P<user>\d+)"
+    r"-(?P<gesture>\d+)"
+    r"-(?P<position>\d+)"
+    r"-(?P<orientation>\d+)"
+    r"-(?P<instance>\d+)"
+    r"-r(?P<receiver>\d+)\.dat$"
+)
+
+
+def parse_widar3_filename(name: str) -> dict:
+    """Parse a Widar3.0 .dat filename into its integer slots.
+
+    Raises ValueError if the name doesn't match the expected pattern.
+    """
+    m = WIDAR3_FILENAME_RE.match(name)
+    if m is None:
+        raise ValueError(f"not a Widar3.0 filename: {name!r}")
+    return {k: int(v) for k, v in m.groupdict().items()}
+
+
+def _walk_widar3_root(root: Path) -> list[tuple[Path, dict]]:
+    """Walk `root/<date>/<user>/userN-...-rR.dat` recursively.
+
+    Returns a list of (file_path, parsed_metadata) for every .dat file whose
+    name matches the Widar3.0 pattern. Files that don't match (e.g. .cfg
+    config files, unrelated .dat) are silently skipped.
+    """
+    items: list[tuple[Path, dict]] = []
+    for p in root.rglob("*.dat"):
+        try:
+            meta = parse_widar3_filename(p.name)
+        except ValueError:
+            continue
+        items.append((p, meta))
+    return items
+
+
+def csi_complex_to_real(csi: torch.Tensor) -> torch.Tensor:
+    """Project complex CSI onto a real-valued tensor via magnitude.
+
+    Input shape: `(T, S, A)` complex; output shape: `(T, S, A)` real float32.
+    Same projection as Slice 1 keeps the comparison row honest.
+    """
+    return csi.abs().to(torch.float32)
+
+
+def _crop_or_pad_time(x: torch.Tensor, target_t: int) -> torch.Tensor:
+    """Crop or zero-pad along the time axis (axis 0) to `target_t`."""
+    t = x.shape[0]
+    if t == target_t:
+        return x
+    if t > target_t:
+        return x[:target_t]
+    pad_shape = (target_t - t,) + tuple(x.shape[1:])
+    pad = torch.zeros(pad_shape, dtype=x.dtype, device=x.device)
+    return torch.cat([x, pad], dim=0)
+
+
+def load_widar3_dat(
+    path: Path,
+    time_steps: int = CSI_T,
+    nrxnum: int = 3,
+    ntxnum: int = 1,
+) -> torch.Tensor:
+    """Parse one Widar3.0 .dat into a `(time_steps, S, A)` real tensor.
+
+    Uses `csiread.Intel` with the Widar3.0-standard 1-TX × 3-RX shape;
+    csiread's library default `ntxnum=2` would silently produce 6 antenna
+    channels and break the encoder.
+    """
+    import csiread
+
+    parser = csiread.Intel(str(path), nrxnum=nrxnum, ntxnum=ntxnum)
+    parser.read()
+    csi = torch.from_numpy(parser.get_scaled_csi())  # (T, S, Nrx, Ntx) complex
+    if csi.ndim == 4:
+        csi = csi.reshape(csi.shape[0], csi.shape[1], -1)
+    real = csi_complex_to_real(csi)
+    return _crop_or_pad_time(real, time_steps)
+
+
+class Widar3CrossSubject(Dataset):
+    """Widar3.0 cross-subject gesture-recognition dataset.
+
+    Args mirror Slice 1's `Widar3CrossSubject`. The cross-subject split
+    convention is shared (default test on user IDs 1-4) so Slice 5's
+    supervised baseline reports a number directly comparable to Slice 1's
+    Doppler-aware augmentation result. If the team later decides to change
+    the canonical split, both slices update together.
+
+    Args:
+        root: directory containing Widar3.0 `.dat` files (recursively).
+        train: True for the training split (subjects ∉ test_subjects);
+            False for the held-out test split.
+        test_subjects: list of user IDs held out as the cross-subject test
+            set. Default `[1, 2, 3, 4]` matches Slice 1's convention.
+        time_steps: fixed length all samples are cropped/padded to.
+        num_classes: number of gesture classes.
+        cache_path: optional path for a parsed-tensor cache. If set and the
+            cache exists, the dataset loads from it instead of re-parsing
+            every `.dat` on `__init__`.
+    """
+
+    DEFAULT_TEST_SUBJECTS: list[int] = [1, 2, 3, 4]
+
+    def __init__(
+        self,
+        root: str | Path,
+        train: bool = True,
+        test_subjects: list[int] | None = None,
+        time_steps: int = CSI_T,
+        num_classes: int = NUM_CLASSES,
+        cache_path: str | Path | None = None,
+    ) -> None:
+        self.root = Path(root)
+        self.train = train
+        self.test_subjects = list(
+            self.DEFAULT_TEST_SUBJECTS if test_subjects is None else test_subjects
+        )
+        self.time_steps = time_steps
+        self.num_classes = num_classes
+        self.cache_path = Path(cache_path) if cache_path else None
+
+        cache_meta = {
+            "train": self.train,
+            "test_subjects": sorted(self.test_subjects),
+            "time_steps": self.time_steps,
+            "num_classes": self.num_classes,
+        }
+
+        if self.cache_path is not None and self.cache_path.exists():
+            blob = torch.load(self.cache_path, weights_only=False)
+            cached_meta = blob.get("meta", {})
+            if cached_meta != cache_meta:
+                raise ValueError(
+                    f"cache at {self.cache_path} was built with {cached_meta!r} "
+                    f"but loader requested {cache_meta!r}; pass a different "
+                    "cache_path or delete the existing one"
+                )
+            self._x = blob["x"]
+            self._y = blob["y"]
+            return
+
+        items = _walk_widar3_root(self.root)
+        if self.train:
+            items = [it for it in items if it[1]["user"] not in self.test_subjects]
+        else:
+            items = [it for it in items if it[1]["user"] in self.test_subjects]
+        items = [it for it in items if 1 <= it[1]["gesture"] <= self.num_classes]
+
+        if len(items) == 0:
+            raise RuntimeError(
+                f"no Widar3.0 .dat files found under {self.root!r}; check the "
+                "data root path or extract a CSI archive first"
+            )
+
+        xs: list[torch.Tensor] = []
+        ys: list[int] = []
+        for path, meta in items:
+            xs.append(load_widar3_dat(path, time_steps=self.time_steps))
+            ys.append(meta["gesture"] - 1)  # to 0-indexed
+
+        self._x = torch.stack(xs, dim=0)
+        self._y = torch.tensor(ys, dtype=torch.long)
+
+        if self.cache_path is not None:
+            self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+            torch.save(
+                {"x": self._x, "y": self._y, "meta": cache_meta},
+                self.cache_path,
+            )
 
     def __len__(self) -> int:
         return self._x.shape[0]

--- a/src/slices/josiah/run.py
+++ b/src/slices/josiah/run.py
@@ -1,15 +1,14 @@
-"""End-to-end smoke run for Slice 5 (T5.1).
+"""End-to-end run for Slice 5.
 
-Wires StubCSI -> TinyCNN encoder -> linear classifier -> cross-entropy
-training -> top-1 accuracy. T5.1 only proves the pipeline runs; the
-printed accuracy is not meaningful (chance level on random labels).
+T5.1 (default) wires StubCSI -> TinyCNN encoder -> linear classifier ->
+cross-entropy training -> top-1 accuracy. Stub data, accuracy at chance.
 
-T5.2 will replace the stub data with a real Widar3.0 cross-subject loader.
-T5.6 will be the hand-crafted-aug SimCLR baseline that the project's
-physics-informed augmentations have to beat.
+T5.2 adds the `--real` flag to swap in `Widar3CrossSubject`. The same
+training and eval code then produces a defensible cross-subject accuracy.
 
 Run:
-    python -m src.slices.josiah.run
+    python -m src.slices.josiah.run                     # stub data (T5.1)
+    python -m src.slices.josiah.run --real --epochs 10  # real data (T5.2)
 """
 
 from __future__ import annotations
@@ -21,7 +20,7 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
-from .data import CSI_A, CSI_S, NUM_CLASSES, StubCSI
+from .data import CSI_A, CSI_S, NUM_CLASSES, StubCSI, Widar3CrossSubject
 from .encoder import SupervisedClassifier, count_parameters
 from .eval import evaluate, train_supervised
 
@@ -36,12 +35,32 @@ def main(
     seed: int = 42,
     epochs: int = 2,
     batch_size: int = 4,
+    real: bool = False,
+    data_root: str = "data/widar3/raw",
+    cache_dir: str = "data/widar3/cache",
 ) -> float:
     set_seed(seed)
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
-    train_ds = StubCSI(num_samples=10, seed=seed)
-    test_ds = StubCSI(num_samples=10, seed=seed + 1)
+    if real:
+        train_ds = Widar3CrossSubject(
+            root=data_root,
+            train=True,
+            cache_path=f"{cache_dir}/josiah_train.pt",
+        )
+        test_ds = Widar3CrossSubject(
+            root=data_root,
+            train=False,
+            cache_path=f"{cache_dir}/josiah_test.pt",
+        )
+        print(
+            f"[T5.2] real Widar3.0 cross-subject; "
+            f"train={len(train_ds)}, test={len(test_ds)}"
+        )
+    else:
+        train_ds = StubCSI(num_samples=10, seed=seed)
+        test_ds = StubCSI(num_samples=10, seed=seed + 1)
+        print(f"[T5.1] stub data; train={len(train_ds)}, test={len(test_ds)}")
 
     train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
     test_loader = DataLoader(test_ds, batch_size=batch_size, shuffle=False)
@@ -49,19 +68,17 @@ def main(
     model = SupervisedClassifier(
         in_channels=CSI_S * CSI_A, num_classes=NUM_CLASSES, feature_dim=128
     )
-    print(f"[T5.1] model params: {count_parameters(model)}")
+    print(f"[josiah] model params: {count_parameters(model)}")
 
     losses = train_supervised(
         model, train_loader, epochs=epochs, lr=1e-3, device=device
     )
-    print(f"[T5.1] supervised train losses: " f"{[round(loss, 4) for loss in losses]}")
+    print(f"[josiah] train losses: {[round(loss, 4) for loss in losses]}")
 
     acc = evaluate(model, test_loader, device=device)
     chance = 1.0 / NUM_CLASSES
-    print(
-        f"[T5.1] supervised top-1 accuracy on stub data: {acc:.3f} "
-        f"(chance ~ {chance:.3f}; not meaningful - stub labels are random)"
-    )
+    tag = "T5.2" if real else "T5.1"
+    print(f"[{tag}] supervised top-1 accuracy: {acc:.3f} (chance ~ {chance:.3f})")
     return acc
 
 
@@ -70,9 +87,31 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--epochs", type=int, default=2)
     p.add_argument("--batch-size", type=int, default=4)
+    p.add_argument(
+        "--real",
+        action="store_true",
+        help="Use real Widar3.0 data (T5.2); default is stub (T5.1).",
+    )
+    p.add_argument(
+        "--data-root",
+        default="data/widar3/raw",
+        help="Directory containing Widar3.0 .dat files (recursive).",
+    )
+    p.add_argument(
+        "--cache-dir",
+        default="data/widar3/cache",
+        help="Directory for cached parsed tensors.",
+    )
     return p.parse_args()
 
 
 if __name__ == "__main__":
     args = _parse_args()
-    main(seed=args.seed, epochs=args.epochs, batch_size=args.batch_size)
+    main(
+        seed=args.seed,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        real=args.real,
+        data_root=args.data_root,
+        cache_dir=args.cache_dir,
+    )

--- a/tests/slices/josiah/test_widar3_loader.py
+++ b/tests/slices/josiah/test_widar3_loader.py
@@ -1,0 +1,77 @@
+"""Unit tests for Slice 5's Widar3.0 cross-subject loader.
+
+Data-dependent parts (csiread parsing, end-to-end smoke on real `.dat`
+files) are exercised in T5.2's real-data run. These tests cover the
+parts that don't need a Widar3.0 install: filename parsing, time-axis
+crop/pad, and the complex->real projection.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.slices.josiah.data import (
+    _crop_or_pad_time,
+    csi_complex_to_real,
+    parse_widar3_filename,
+)
+
+
+def test_parse_widar3_filename_canonical() -> None:
+    meta = parse_widar3_filename("user1-5-4-2-15-r5.dat")
+    assert meta == {
+        "user": 1,
+        "gesture": 5,
+        "position": 4,
+        "orientation": 2,
+        "instance": 15,
+        "receiver": 5,
+    }
+
+
+def test_parse_widar3_filename_multidigit_user() -> None:
+    meta = parse_widar3_filename("user12-1-1-1-1-r1.dat")
+    assert meta["user"] == 12
+
+
+def test_parse_widar3_filename_rejects_garbage() -> None:
+    with pytest.raises(ValueError):
+        parse_widar3_filename("notawidar3file.dat")
+    with pytest.raises(ValueError):
+        parse_widar3_filename("user1-5-4-2-15.dat")  # missing -rR
+    with pytest.raises(ValueError):
+        parse_widar3_filename("config.cfg")
+
+
+def test_crop_or_pad_time_crops() -> None:
+    x = torch.arange(20, dtype=torch.float32).reshape(20, 1, 1)
+    out = _crop_or_pad_time(x, target_t=5)
+    assert out.shape == (5, 1, 1)
+    # The first 5 elements should be preserved.
+    assert torch.equal(out, x[:5])
+
+
+def test_crop_or_pad_time_pads() -> None:
+    x = torch.ones((3, 2, 4), dtype=torch.float32)
+    out = _crop_or_pad_time(x, target_t=7)
+    assert out.shape == (7, 2, 4)
+    # First 3 rows should be unchanged ones; remaining 4 are zero.
+    assert torch.equal(out[:3], x)
+    assert torch.equal(out[3:], torch.zeros((4, 2, 4)))
+
+
+def test_crop_or_pad_time_identity() -> None:
+    x = torch.randn(10, 3, 2)
+    out = _crop_or_pad_time(x, target_t=10)
+    assert torch.equal(out, x)
+
+
+def test_csi_complex_to_real_projection() -> None:
+    # Pure imaginary input has magnitude equal to the absolute value.
+    z = torch.complex(torch.zeros(2, 2, 2), torch.tensor([[[3.0, 4.0]] * 2] * 2))
+    out = csi_complex_to_real(z)
+    assert out.dtype == torch.float32
+    assert out.shape == z.shape
+    expected = z.abs().to(torch.float32)
+    assert torch.allclose(out, expected)


### PR DESCRIPTION
Second Slice 5 tracer-bullet. Adds \`Widar3CrossSubject\` to \`src/slices/josiah/data.py\` plus helpers (filename parsing, crop/pad, complex->real projection, csiread.Intel parser), ported from Slice 1 per the slice-independence rule.

Default cross-subject split is \`test_subjects=[1,2,3,4]\`, matching Slice 1 so the rows in the team's comparison figure are directly comparable.

\`run.py\` grows a \`--real\` flag. Smoke-tested on extracted \`CSI_20181128.zip\`: csiread parses cleanly, produces \`(100, 30, 3)\` float32 tensors.

8 unit tests (1 supervised-smoke + 7 loader-unit) all pass; lint green.

The 3-seed cross-subject supervised training run on real data is the next step; tracked as a follow-up since it's an execution task rather than a code-change task.

Closes #67.