### PR TITLE
T5.3 — SimCLR pre-training with trivial augmentation (random crop only)

### DIFF
--- a/src/slices/josiah/augmentations.py
+++ b/src/slices/josiah/augmentations.py
@@ -1,0 +1,50 @@
+"""Augmentation functions for Slice 5's SSL baselines.
+
+T5.3 uses `random_crop` only — the trivial-augmentation baseline that
+tests "does SSL help at all on CSI?" T5.6 will add `gaussian_noise` and
+`random_subcarrier_mask` for the hand-crafted-augmentation baseline (the
+comparison column for slices 1, 2, 4, 6).
+
+Each augmentation accepts a batch shaped `(B, T, S, A)` or a single sample
+`(T, S, A)` and returns the same shape (cropping is followed by zero-pad
+back to the original `T` so the encoder's batch dim stays consistent).
+Two independent calls produce two independent views; see `ssl.make_views`.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def random_crop(x: torch.Tensor, crop_ratio: float = 0.7) -> torch.Tensor:
+    """Random temporal crop, padded back to the original length.
+
+    Sample a start index per call (shared across the batch for simplicity)
+    so the two SimCLR views differ by their random crops. The cropped
+    segment is zero-padded back to the original `T` to keep the encoder's
+    input length stable across batches.
+
+    Args:
+        x: `(B, T, S, A)` or `(T, S, A)`.
+        crop_ratio: fraction of `T` retained per view. 0.7 → 30% of the
+            time axis is zero-padded, leaving the encoder a 70%-length
+            random window.
+
+    Returns:
+        Same shape as `x`; cropped window placed at the start, rest zeroed.
+    """
+    if x.ndim not in (3, 4):
+        raise ValueError(f"expected (B, T, S, A) or (T, S, A); got ndim={x.ndim}")
+    t = x.shape[-3]
+    t_crop = max(1, int(t * crop_ratio))
+    max_start = t - t_crop
+    start = int(torch.randint(0, max_start + 1, (1,)).item())
+    if x.ndim == 4:
+        cropped = x[:, start : start + t_crop, :, :]
+        out = torch.zeros_like(x)
+        out[:, :t_crop, :, :] = cropped
+    else:
+        cropped = x[start : start + t_crop, :, :]
+        out = torch.zeros_like(x)
+        out[:t_crop, :, :] = cropped
+    return out

--- a/src/slices/josiah/eval.py
+++ b/src/slices/josiah/eval.py
@@ -1,18 +1,22 @@
-"""Supervised train + accuracy eval for Slice 5.
+"""Evaluation routines for Slice 5.
 
-The Slice 5 supervised baseline trains a `SupervisedClassifier` end-to-end
-with cross-entropy against the gesture label. No SSL pre-training, no
-augmentation other than what's needed to batch the data. This is the floor
-of the comparison-to-conventional-solutions: every SSL method we report
-later has to beat the supervised baseline to be worth anything.
+Two protocols, both in the project conventions:
 
-`train_supervised` returns the per-epoch training-loss trajectory; `evaluate`
-returns the test-set classification accuracy.
+- **Supervised** (`train_supervised` + `evaluate`): cross-entropy on the
+  full classifier, reported via top-1 test accuracy. The supervised
+  baseline (T5.2) uses this and only this.
+
+- **Linear probe** (`linear_probe`): freeze the SSL-pre-trained encoder,
+  fit a logistic-regression classifier on its features, return test-set
+  accuracy. Used by every SSL row (T5.3 trivial-aug, T5.6 hand-crafted-aug,
+  T5.4 AutoFi, T5.5 CAPC).
 """
 
 from __future__ import annotations
 
+import numpy as np
 import torch
+from sklearn.linear_model import LogisticRegression
 from torch import nn
 from torch.utils.data import DataLoader
 
@@ -68,3 +72,47 @@ def evaluate(
     if total == 0:
         return 0.0
     return correct / total
+
+
+@torch.no_grad()
+def extract_features(
+    encoder: nn.Module,
+    loader: DataLoader,
+    device: str = "cpu",
+) -> tuple[np.ndarray, np.ndarray]:
+    """Run the (frozen) encoder over `loader`, returning feature/label arrays."""
+    encoder.eval()
+    encoder.to(device)
+    features: list[np.ndarray] = []
+    labels: list[np.ndarray] = []
+    for batch in loader:
+        x, y = batch
+        x = x.to(device).float()
+        x = reshape_csi_for_encoder(x)
+        h = encoder(x)
+        features.append(h.cpu().numpy())
+        labels.append(np.asarray(y))
+    return np.concatenate(features, axis=0), np.concatenate(labels, axis=0)
+
+
+def linear_probe(
+    encoder: nn.Module,
+    train_loader: DataLoader,
+    test_loader: DataLoader,
+    *,
+    device: str = "cpu",
+    max_iter: int = 1000,
+    seed: int = 42,
+) -> float:
+    """Fit a linear classifier on frozen-encoder features; return test accuracy.
+
+    Matches Slice 1's protocol: scikit-learn's LogisticRegression on the
+    encoder's `(B, feature_dim)` outputs, evaluated as top-1 accuracy.
+    """
+    train_x, train_y = extract_features(encoder, train_loader, device=device)
+    test_x, test_y = extract_features(encoder, test_loader, device=device)
+
+    clf = LogisticRegression(max_iter=max_iter, random_state=seed)
+    clf.fit(train_x, train_y)
+    pred = clf.predict(test_x)
+    return float(np.mean(pred == test_y))

--- a/src/slices/josiah/run.py
+++ b/src/slices/josiah/run.py
@@ -1,14 +1,19 @@
 """End-to-end run for Slice 5.
 
-T5.1 (default) wires StubCSI -> TinyCNN encoder -> linear classifier ->
-cross-entropy training -> top-1 accuracy. Stub data, accuracy at chance.
+Three baselines wired through `--mode`:
 
-T5.2 adds the `--real` flag to swap in `Widar3CrossSubject`. The same
-training and eval code then produces a defensible cross-subject accuracy.
+- `mode=supervised` (T5.1 / T5.2): cross-entropy on the full classifier.
+- `mode=simclr-trivial` (T5.3): SimCLR pre-train with `random_crop` only,
+  then frozen-encoder linear probe.
+- `mode=simclr-handcrafted` (T5.6): SimCLR pre-train with the
+  hand-crafted-augmentation baseline (added in T5.6).
+
+Each mode supports `--real` to swap stub data for real Widar3.0 cross-subject.
 
 Run:
-    python -m src.slices.josiah.run                     # stub data (T5.1)
-    python -m src.slices.josiah.run --real --epochs 10  # real data (T5.2)
+    python -m src.slices.josiah.run                                   # supervised stub
+    python -m src.slices.josiah.run --real --epochs 10                # supervised real
+    python -m src.slices.josiah.run --mode simclr-trivial --real      # T5.3 real
 """
 
 from __future__ import annotations
@@ -20,9 +25,11 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
+from .augmentations import random_crop
 from .data import CSI_A, CSI_S, NUM_CLASSES, StubCSI, Widar3CrossSubject
-from .encoder import SupervisedClassifier, count_parameters
-from .eval import evaluate, train_supervised
+from .encoder import SupervisedClassifier, TinyCNN, count_parameters
+from .eval import evaluate, linear_probe, train_supervised
+from .ssl import SimCLR, pretrain_simclr
 
 
 def set_seed(seed: int) -> None:
@@ -31,7 +38,29 @@ def set_seed(seed: int) -> None:
     torch.manual_seed(seed)
 
 
+def _make_datasets(
+    real: bool, seed: int, data_root: str, cache_dir: str
+) -> tuple[torch.utils.data.Dataset, torch.utils.data.Dataset]:
+    if real:
+        train_ds = Widar3CrossSubject(
+            root=data_root, train=True, cache_path=f"{cache_dir}/josiah_train.pt"
+        )
+        test_ds = Widar3CrossSubject(
+            root=data_root, train=False, cache_path=f"{cache_dir}/josiah_test.pt"
+        )
+        print(
+            f"[josiah] real Widar3.0 cross-subject; "
+            f"train={len(train_ds)}, test={len(test_ds)}"
+        )
+    else:
+        train_ds = StubCSI(num_samples=10, seed=seed)
+        test_ds = StubCSI(num_samples=10, seed=seed + 1)
+        print(f"[josiah] stub data; train={len(train_ds)}, test={len(test_ds)}")
+    return train_ds, test_ds
+
+
 def main(
+    mode: str = "supervised",
     seed: int = 42,
     epochs: int = 2,
     batch_size: int = 4,
@@ -42,72 +71,80 @@ def main(
     set_seed(seed)
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
-    if real:
-        train_ds = Widar3CrossSubject(
-            root=data_root,
-            train=True,
-            cache_path=f"{cache_dir}/josiah_train.pt",
-        )
-        test_ds = Widar3CrossSubject(
-            root=data_root,
-            train=False,
-            cache_path=f"{cache_dir}/josiah_test.pt",
-        )
-        print(
-            f"[T5.2] real Widar3.0 cross-subject; "
-            f"train={len(train_ds)}, test={len(test_ds)}"
-        )
-    else:
-        train_ds = StubCSI(num_samples=10, seed=seed)
-        test_ds = StubCSI(num_samples=10, seed=seed + 1)
-        print(f"[T5.1] stub data; train={len(train_ds)}, test={len(test_ds)}")
-
-    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+    train_ds, test_ds = _make_datasets(real, seed, data_root, cache_dir)
+    train_loader = DataLoader(
+        train_ds, batch_size=batch_size, shuffle=True, drop_last=(mode != "supervised")
+    )
     test_loader = DataLoader(test_ds, batch_size=batch_size, shuffle=False)
 
-    model = SupervisedClassifier(
-        in_channels=CSI_S * CSI_A, num_classes=NUM_CLASSES, feature_dim=128
-    )
-    print(f"[josiah] model params: {count_parameters(model)}")
+    if mode == "supervised":
+        model = SupervisedClassifier(
+            in_channels=CSI_S * CSI_A, num_classes=NUM_CLASSES, feature_dim=128
+        )
+        print(f"[josiah] supervised model params: {count_parameters(model)}")
+        losses = train_supervised(
+            model, train_loader, epochs=epochs, lr=1e-3, device=device
+        )
+        print(f"[josiah] train losses: {[round(loss, 4) for loss in losses]}")
+        acc = evaluate(model, test_loader, device=device)
+        print(f"[josiah] supervised top-1 accuracy: {acc:.3f}")
+        return acc
 
-    losses = train_supervised(
-        model, train_loader, epochs=epochs, lr=1e-3, device=device
-    )
-    print(f"[josiah] train losses: {[round(loss, 4) for loss in losses]}")
+    if mode == "simclr-trivial":
+        encoder = TinyCNN(in_channels=CSI_S * CSI_A, feature_dim=128)
+        print(f"[T5.3] encoder params: {count_parameters(encoder)}")
+        ssl_model = SimCLR(encoder, feature_dim=128, projection_dim=64)
+        losses = pretrain_simclr(
+            ssl_model,
+            train_loader,
+            epochs=epochs,
+            lr=1e-3,
+            temperature=0.5,
+            augment_fn=random_crop,
+            device=device,
+        )
+        print(f"[T5.3] SSL pre-train losses: {[round(loss, 4) for loss in losses]}")
 
-    acc = evaluate(model, test_loader, device=device)
-    chance = 1.0 / NUM_CLASSES
-    tag = "T5.2" if real else "T5.1"
-    print(f"[{tag}] supervised top-1 accuracy: {acc:.3f} (chance ~ {chance:.3f})")
-    return acc
+        # Linear probe on the frozen encoder
+        probe_train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=False)
+        acc = linear_probe(
+            ssl_model.encoder,
+            probe_train_loader,
+            test_loader,
+            device=device,
+            seed=seed,
+        )
+        print(f"[T5.3] linear-probe accuracy: {acc:.3f}")
+        return acc
+
+    raise ValueError(f"unknown mode: {mode!r}")
 
 
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser()
+    p.add_argument(
+        "--mode",
+        choices=["supervised", "simclr-trivial"],
+        default="supervised",
+        help="Baseline mode. T5.6's simclr-handcrafted lands later.",
+    )
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--epochs", type=int, default=2)
     p.add_argument("--batch-size", type=int, default=4)
     p.add_argument(
         "--real",
         action="store_true",
-        help="Use real Widar3.0 data (T5.2); default is stub (T5.1).",
+        help="Use real Widar3.0 data; default is stub.",
     )
-    p.add_argument(
-        "--data-root",
-        default="data/widar3/raw",
-        help="Directory containing Widar3.0 .dat files (recursive).",
-    )
-    p.add_argument(
-        "--cache-dir",
-        default="data/widar3/cache",
-        help="Directory for cached parsed tensors.",
-    )
+    p.add_argument("--data-root", default="data/widar3/raw")
+    p.add_argument("--cache-dir", default="data/widar3/cache")
     return p.parse_args()
 
 
 if __name__ == "__main__":
     args = _parse_args()
     main(
+        mode=args.mode,
         seed=args.seed,
         epochs=args.epochs,
         batch_size=args.batch_size,

--- a/src/slices/josiah/ssl.py
+++ b/src/slices/josiah/ssl.py
@@ -1,0 +1,121 @@
+"""SimCLR wrapper, projection head, and NT-Xent loss for Slice 5.
+
+Ported from Slice 1's SSL module per the slice-independence convention in
+`docs/08-team-work-plan.md` section 2. Same architecture so the baselines
+shipped in T5.3 (trivial-aug) and T5.6 (hand-crafted-aug) sit on the same
+SSL machinery as Slice 1's Doppler-aware run, isolating "augmentation
+choice" as the only changing variable in the team's comparison figure.
+
+The augmentation function is a hook (`augment_fn`) so the same SimCLR
+plumbing serves both T5.3 (random crop) and T5.6 (Gaussian + mask).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from .encoder import reshape_csi_for_encoder
+
+AugmentFn = Callable[[torch.Tensor], torch.Tensor]
+
+
+class ProjectionHead(nn.Module):
+    def __init__(self, in_dim: int, hidden_dim: int = 128, out_dim: int = 64) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, hidden_dim),
+            nn.ReLU(inplace=True),
+            nn.Linear(hidden_dim, out_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class SimCLR(nn.Module):
+    def __init__(
+        self, encoder: nn.Module, feature_dim: int, projection_dim: int = 64
+    ) -> None:
+        super().__init__()
+        self.encoder = encoder
+        self.projection = ProjectionHead(
+            feature_dim, hidden_dim=feature_dim, out_dim=projection_dim
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.encoder(x)
+        return self.projection(h)
+
+
+def nt_xent_loss(
+    z1: torch.Tensor, z2: torch.Tensor, temperature: float = 0.5
+) -> torch.Tensor:
+    """NT-Xent (normalized temperature-scaled cross-entropy) loss.
+
+    z1, z2: `(B, D)` projection-head outputs for the two augmented views.
+    """
+    b = z1.shape[0]
+    z = torch.cat([z1, z2], dim=0)
+    z = F.normalize(z, dim=1)
+
+    sim = z @ z.t() / temperature
+    sim.fill_diagonal_(float("-inf"))
+
+    targets = torch.arange(2 * b, device=z.device)
+    targets = (targets + b) % (2 * b)
+
+    return F.cross_entropy(sim, targets)
+
+
+def make_views(
+    batch: torch.Tensor,
+    augment_fn: Optional[AugmentFn] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build the SimCLR (view1, view2) pair.
+
+    Two independent calls to `augment_fn` produce two views with different
+    randomness. If `augment_fn` is None, both views are the original batch
+    (still useful for plumbing checks; contrastive signal weak).
+    """
+    if augment_fn is None:
+        v1, v2 = batch, batch
+    else:
+        v1, v2 = augment_fn(batch), augment_fn(batch)
+    return reshape_csi_for_encoder(v1), reshape_csi_for_encoder(v2)
+
+
+def pretrain_simclr(
+    model: SimCLR,
+    loader: torch.utils.data.DataLoader,
+    *,
+    epochs: int,
+    lr: float = 1e-3,
+    temperature: float = 0.5,
+    augment_fn: Optional[AugmentFn] = None,
+    device: str = "cpu",
+) -> list[float]:
+    """Run SimCLR pre-training. Returns per-epoch mean losses."""
+    model.to(device)
+    model.train()
+    optim = torch.optim.Adam(model.parameters(), lr=lr)
+
+    epoch_losses: list[float] = []
+    for _ in range(epochs):
+        batch_losses: list[float] = []
+        for batch in loader:
+            x = batch[0] if isinstance(batch, (list, tuple)) else batch
+            x = x.to(device).float()
+            v1, v2 = make_views(x, augment_fn=augment_fn)
+            z1 = model(v1)
+            z2 = model(v2)
+            loss = nt_xent_loss(z1, z2, temperature=temperature)
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+            batch_losses.append(loss.item())
+        epoch_losses.append(sum(batch_losses) / max(1, len(batch_losses)))
+    return epoch_losses

--- a/tests/slices/josiah/test_ssl.py
+++ b/tests/slices/josiah/test_ssl.py
@@ -1,0 +1,68 @@
+"""Unit tests for Slice 5's SSL machinery (T5.3).
+
+Covers NT-Xent shape/finiteness, `make_views` randomness, `random_crop`
+preserves shape, and a one-batch SimCLR step doesn't blow up.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from src.slices.josiah.augmentations import random_crop
+from src.slices.josiah.encoder import TinyCNN
+from src.slices.josiah.ssl import SimCLR, make_views, nt_xent_loss
+
+
+def test_nt_xent_finite() -> None:
+    z1 = torch.randn(4, 8)
+    z2 = torch.randn(4, 8)
+    loss = nt_xent_loss(z1, z2, temperature=0.5)
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
+    assert loss.item() > 0
+
+
+def test_random_crop_preserves_shape() -> None:
+    x = torch.randn(2, 100, 30, 3)
+    out = random_crop(x, crop_ratio=0.7)
+    assert out.shape == x.shape
+    # The last ~30% of the time axis should be zeros (padding region).
+    # Exact zero region depends on the random start; just check sparsity:
+    zero_ratio = (out == 0).float().mean().item()
+    assert zero_ratio > 0.0
+
+
+def test_random_crop_two_views_differ() -> None:
+    torch.manual_seed(0)
+    x = torch.randn(2, 100, 30, 3)
+    v1 = random_crop(x, crop_ratio=0.7)
+    v2 = random_crop(x, crop_ratio=0.7)
+    # Two independent calls should produce two different starts -> different outputs.
+    # With 30 possible start positions, the collision probability is ~1/30,
+    # so this assertion is robust under fixed seed.
+    assert not torch.equal(v1, v2)
+
+
+def test_make_views_returns_encoder_shape() -> None:
+    x = torch.randn(2, 100, 30, 3)
+    v1, v2 = make_views(x, augment_fn=random_crop)
+    # Encoder expects (B, S*A, T) = (2, 90, 100).
+    assert v1.shape == (2, 90, 100)
+    assert v2.shape == (2, 90, 100)
+
+
+def test_simclr_one_step_runs() -> None:
+    encoder = TinyCNN(in_channels=30 * 3, feature_dim=128)
+    model = SimCLR(encoder, feature_dim=128, projection_dim=64)
+    model.train()
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    x = torch.randn(4, 100, 30, 3)
+    v1, v2 = make_views(x, augment_fn=random_crop)
+    z1 = model(v1)
+    z2 = model(v2)
+    loss = nt_xent_loss(z1, z2, temperature=0.5)
+    opt.zero_grad()
+    loss.backward()
+    opt.step()
+    assert torch.isfinite(loss)


### PR DESCRIPTION
Third Slice 5 tracer-bullet. Adds SimCLR pre-training to Josiah's slice with random_crop as the sole augmentation; frozen-encoder linear probe for eval. The "does SSL help at all on CSI, even with the dumbest augmentation?" baseline.

New: ssl.py (ProjectionHead, SimCLR, NT-Xent, pretrain loop), augmentations.py (random_crop), linear_probe in eval.py, --mode flag in run.py.

13 unit tests green (5 new for the SSL machinery); lint clean.

Stub smoke: SimCLR pre-train loss decreases monotonically over 2 epochs.

Closes #68.