### PR TITLE
T5.6 — Hand-crafted-augmentation SimCLR baseline (comparison column)

### DIFF
--- a/src/slices/josiah/augmentations.py
+++ b/src/slices/josiah/augmentations.py
@@ -1,14 +1,16 @@
 """Augmentation functions for Slice 5's SSL baselines.
 
-T5.3 uses `random_crop` only — the trivial-augmentation baseline that
-tests "does SSL help at all on CSI?" T5.6 will add `gaussian_noise` and
-`random_subcarrier_mask` for the hand-crafted-augmentation baseline (the
-comparison column for slices 1, 2, 4, 6).
+- `random_crop` (T5.3) — trivial-augmentation baseline. Tests "does SSL
+  help at all on CSI, even with the dumbest augmentation?"
+- `gaussian_noise` + `random_subcarrier_mask` + `gaussian_then_mask` (T5.6)
+  — hand-crafted-augmentation baseline. This is the comparison-column row
+  every physics-informed augmentation slice (1, 2, 4, 6) measures against.
+  Ported from Slice 1 per the slice-independence rule so the comparison
+  is apples-to-apples (same augmentation parameters).
 
 Each augmentation accepts a batch shaped `(B, T, S, A)` or a single sample
-`(T, S, A)` and returns the same shape (cropping is followed by zero-pad
-back to the original `T` so the encoder's batch dim stays consistent).
-Two independent calls produce two independent views; see `ssl.make_views`.
+`(T, S, A)` and returns the same shape. Two independent calls produce two
+independent views; see `ssl.make_views`.
 """
 
 from __future__ import annotations
@@ -48,3 +50,53 @@ def random_crop(x: torch.Tensor, crop_ratio: float = 0.7) -> torch.Tensor:
         out = torch.zeros_like(x)
         out[:t_crop, :, :] = cropped
     return out
+
+
+# ---------------------------------------------------------------------------
+# T5.6 hand-crafted-augmentation baseline
+# Gaussian noise + random subcarrier masking, ported from Slice 1. Same
+# parameters as Slice 1 so the comparison row sits on identical augmentations.
+
+
+def gaussian_noise(x: torch.Tensor, sigma: float = 0.05) -> torch.Tensor:
+    """Additive Gaussian noise on every CSI element.
+
+    `sigma` matches Slice 1's default. Pick it small relative to the typical
+    CSI magnitude after the projection / normalisation upstream.
+    """
+    return x + torch.randn_like(x) * sigma
+
+
+def random_subcarrier_mask(x: torch.Tensor, p: float = 0.15) -> torch.Tensor:
+    """Zero out a random fraction `p` of subcarriers per sample.
+
+    Operates on `(T, S, A)` or `(B, T, S, A)`. In the batched path each
+    sample gets its own independent mask so two calls produce two views
+    with different masked-out subcarriers — the SimCLR view-pair recipe.
+    """
+    if x.ndim == 3:
+        s = x.shape[1]
+        keep = torch.rand(s, device=x.device) >= p
+        return x * keep.view(1, s, 1).to(x.dtype)
+    if x.ndim == 4:
+        b, _, s, _ = x.shape
+        keep = torch.rand(b, s, device=x.device) >= p
+        return x * keep.view(b, 1, s, 1).to(x.dtype)
+    raise ValueError(
+        f"random_subcarrier_mask expects (T, S, A) or (B, T, S, A); "
+        f"got {tuple(x.shape)}"
+    )
+
+
+def gaussian_then_mask(
+    x: torch.Tensor, sigma: float = 0.05, p: float = 0.15
+) -> torch.Tensor:
+    """T5.6 default view augmentation: Gaussian noise then subcarrier mask.
+
+    Used symmetrically (both views call this) to produce the hand-crafted-
+    augmentation baseline. The composition order — noise first, mask
+    second — matches Slice 1's `gaussian_then_mask` so the comparison
+    rows are byte-identical augmentation pipelines, only the encoder
+    pre-training augmentation set differs across rows.
+    """
+    return random_subcarrier_mask(gaussian_noise(x, sigma=sigma), p=p)

--- a/src/slices/josiah/run.py
+++ b/src/slices/josiah/run.py
@@ -25,7 +25,7 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
-from .augmentations import random_crop
+from .augmentations import gaussian_then_mask, random_crop
 from .data import CSI_A, CSI_S, NUM_CLASSES, StubCSI, Widar3CrossSubject
 from .encoder import SupervisedClassifier, TinyCNN, count_parameters
 from .eval import evaluate, linear_probe, train_supervised
@@ -90,9 +90,11 @@ def main(
         print(f"[josiah] supervised top-1 accuracy: {acc:.3f}")
         return acc
 
-    if mode == "simclr-trivial":
+    if mode in ("simclr-trivial", "simclr-handcrafted"):
+        tag = "T5.3" if mode == "simclr-trivial" else "T5.6"
+        augment_fn = random_crop if mode == "simclr-trivial" else gaussian_then_mask
         encoder = TinyCNN(in_channels=CSI_S * CSI_A, feature_dim=128)
-        print(f"[T5.3] encoder params: {count_parameters(encoder)}")
+        print(f"[{tag}] encoder params: {count_parameters(encoder)}")
         ssl_model = SimCLR(encoder, feature_dim=128, projection_dim=64)
         losses = pretrain_simclr(
             ssl_model,
@@ -100,10 +102,10 @@ def main(
             epochs=epochs,
             lr=1e-3,
             temperature=0.5,
-            augment_fn=random_crop,
+            augment_fn=augment_fn,
             device=device,
         )
-        print(f"[T5.3] SSL pre-train losses: {[round(loss, 4) for loss in losses]}")
+        print(f"[{tag}] SSL pre-train losses: {[round(loss, 4) for loss in losses]}")
 
         # Linear probe on the frozen encoder
         probe_train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=False)
@@ -114,7 +116,7 @@ def main(
             device=device,
             seed=seed,
         )
-        print(f"[T5.3] linear-probe accuracy: {acc:.3f}")
+        print(f"[{tag}] linear-probe accuracy: {acc:.3f}")
         return acc
 
     raise ValueError(f"unknown mode: {mode!r}")
@@ -124,9 +126,12 @@ def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser()
     p.add_argument(
         "--mode",
-        choices=["supervised", "simclr-trivial"],
+        choices=["supervised", "simclr-trivial", "simclr-handcrafted"],
         default="supervised",
-        help="Baseline mode. T5.6's simclr-handcrafted lands later.",
+        help=(
+            "Baseline mode: supervised (T5.1/T5.2), simclr-trivial (T5.3), "
+            "simclr-handcrafted (T5.6, the comparison-column row)."
+        ),
     )
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--epochs", type=int, default=2)

--- a/tests/slices/josiah/test_handcrafted_aug.py
+++ b/tests/slices/josiah/test_handcrafted_aug.py
@@ -1,0 +1,72 @@
+"""Unit tests for Slice 5's hand-crafted-augmentation baseline (T5.6).
+
+`gaussian_noise`, `random_subcarrier_mask`, and `gaussian_then_mask`
+match Slice 1's implementations so the row in the team's comparison
+figure is byte-identical augmentation pipelines.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.slices.josiah.augmentations import (
+    gaussian_noise,
+    gaussian_then_mask,
+    random_subcarrier_mask,
+)
+
+
+def test_gaussian_noise_changes_input() -> None:
+    torch.manual_seed(0)
+    x = torch.ones(2, 10, 30, 3)
+    out = gaussian_noise(x, sigma=0.1)
+    assert out.shape == x.shape
+    # With sigma=0.1, output should differ from constant input.
+    assert not torch.allclose(out, x)
+    # Difference distribution should have ~zero mean.
+    diff = out - x
+    assert abs(float(diff.mean())) < 0.05
+    # And std close to sigma.
+    assert abs(float(diff.std()) - 0.1) < 0.02
+
+
+def test_random_subcarrier_mask_zeros_some_subcarriers() -> None:
+    torch.manual_seed(0)
+    x = torch.ones(2, 10, 30, 3)
+    out = random_subcarrier_mask(x, p=0.3)
+    assert out.shape == x.shape
+    # Some subcarriers should be entirely zero across the time axis;
+    # others should be entirely one (no per-cell randomness).
+    per_subcarrier_max = out.amax(dim=(1, 3))  # (B, S)
+    zero_subcarriers = (per_subcarrier_max == 0).sum().item()
+    # With p=0.3 on 30 subcarriers across 2 samples, expect around 18
+    # zeroed subcarriers in total; allow a wide tolerance for randomness.
+    assert 5 <= zero_subcarriers <= 35
+
+
+def test_random_subcarrier_mask_per_sample_independence() -> None:
+    """Two samples in the batch should get independent masks."""
+    torch.manual_seed(0)
+    x = torch.ones(2, 10, 30, 3)
+    out = random_subcarrier_mask(x, p=0.5)
+    # The zeroed subcarrier sets per sample should not be identical with very
+    # high probability for B=2, S=30, p=0.5.
+    sample_0_zeros = out[0].amax(dim=(0, 2)) == 0
+    sample_1_zeros = out[1].amax(dim=(0, 2)) == 0
+    assert not torch.equal(sample_0_zeros, sample_1_zeros)
+
+
+def test_gaussian_then_mask_composes() -> None:
+    torch.manual_seed(0)
+    x = torch.ones(2, 10, 30, 3)
+    out = gaussian_then_mask(x, sigma=0.05, p=0.2)
+    assert out.shape == x.shape
+    # Output should differ from input (Gaussian noise was added) and have
+    # some subcarriers fully zero.
+    assert not torch.allclose(out, x)
+
+
+def test_random_subcarrier_mask_rejects_garbage_shape() -> None:
+    with pytest.raises(ValueError):
+        random_subcarrier_mask(torch.zeros(10, 30), p=0.1)


### PR DESCRIPTION
Fourth Slice 5 tracer-bullet (skipping T5.4/T5.5 which need the AutoFi/CAPC papers in hand). T5.6 ships THE comparison-column baseline that every physics-informed augmentation slice (1, 2, 4, 6) measures against.

Adds gaussian_noise + random_subcarrier_mask + gaussian_then_mask to augmentations.py (ported from Slice 1 with identical parameters), --mode simclr-handcrafted to run.py, 5 new unit tests. 18 tests total green; lint clean.

The 3-seed real-data run that populates the figure is the next operation; this PR ships the code.

Closes #71.