### PR TITLE
T4.3 + T4.5 + T4.6: coherence-bw, coherent block-mask, robustness sweep

### DIFF
--- a/src/slices/ihunanya/augmentations.py
+++ b/src/slices/ihunanya/augmentations.py
@@ -1,0 +1,86 @@
+"""Augmentations for Slice 4 (coherence-aware subcarrier masking).
+
+T4.5 ships `coherent_block_mask` — the slice's signature augmentation:
+zero out a contiguous block of `block_width` subcarriers at a random
+start position. `block_width` is the coherence-bandwidth estimate from
+`coherence.py`; the block simulates a realistic frequency-selective
+fading event where a coherent chunk of the spectrum drops out together.
+
+The hand-crafted-aug baseline functions (`gaussian_noise`,
+`random_subcarrier_mask`, `gaussian_then_mask`) are included so this
+slice can run its `simclr-handcrafted` comparison mode self-contained,
+matching Slice 1 / Slice 5 parameters exactly.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def coherent_block_mask(
+    x: torch.Tensor,
+    block_width: int = 5,
+) -> torch.Tensor:
+    """Mask a contiguous block of `block_width` subcarriers.
+
+    Args:
+        x: `(T, S, A)` single sample or `(B, T, S, A)` batched.
+        block_width: number of contiguous subcarriers to zero. Set to
+            the coherence-bandwidth estimate from `coherence.py`.
+
+    Returns:
+        Same shape as `x`. Per-sample random start; two consecutive
+        calls produce two views differing in their mask locations.
+    """
+    if x.ndim not in (3, 4):
+        raise ValueError(f"expected (T, S, A) or (B, T, S, A); got ndim={x.ndim}")
+    s = x.shape[-2]
+    if block_width <= 0:
+        return x
+    if block_width >= s:
+        # Masking everything makes the view degenerate; clamp.
+        block_width = s - 1
+    max_start = s - block_width
+
+    if x.ndim == 3:
+        start = int(torch.randint(0, max_start + 1, (1,)).item())
+        out = x.clone()
+        out[:, start : start + block_width, :] = 0
+        return out
+
+    b = x.shape[0]
+    starts = torch.randint(0, max_start + 1, (b,), device=x.device)
+    out = x.clone()
+    for i in range(b):
+        s_i = int(starts[i].item())
+        out[i, :, s_i : s_i + block_width, :] = 0
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Hand-crafted-aug baseline (same as Slice 1 / Slice 5)
+
+
+def gaussian_noise(x: torch.Tensor, sigma: float = 0.05) -> torch.Tensor:
+    return x + torch.randn_like(x) * sigma
+
+
+def random_subcarrier_mask(x: torch.Tensor, p: float = 0.15) -> torch.Tensor:
+    if x.ndim == 3:
+        s = x.shape[1]
+        keep = torch.rand(s, device=x.device) >= p
+        return x * keep.view(1, s, 1).to(x.dtype)
+    if x.ndim == 4:
+        b, _, s, _ = x.shape
+        keep = torch.rand(b, s, device=x.device) >= p
+        return x * keep.view(b, 1, s, 1).to(x.dtype)
+    raise ValueError(
+        f"random_subcarrier_mask expects (T, S, A) or (B, T, S, A); "
+        f"got {tuple(x.shape)}"
+    )
+
+
+def gaussian_then_mask(
+    x: torch.Tensor, sigma: float = 0.05, p: float = 0.15
+) -> torch.Tensor:
+    return random_subcarrier_mask(gaussian_noise(x, sigma=sigma), p=p)

--- a/src/slices/ihunanya/coherence.py
+++ b/src/slices/ihunanya/coherence.py
@@ -1,0 +1,124 @@
+"""Coherence-bandwidth estimation for Slice 4 (T4.3).
+
+The slice masks blocks of contiguous subcarriers matching the channel's
+coherence bandwidth — the frequency width over which adjacent subcarriers
+remain correlated (they fade together rather than independently). The
+block width is the integer "how many subcarriers stay coherent" rather
+than a continuous Hz value, since the encoder operates on a fixed
+30-subcarrier discrete grid.
+
+Two estimators, both supported:
+
+1. **Frequency-domain autocorrelation** (default). For each sample,
+   compute the lagged subcarrier-vs-subcarrier autocorrelation of the
+   magnitude. The smallest lag at which |autocorr| drops below a
+   threshold (default 0.5) is the coherence bandwidth in subcarriers.
+   Works on the real-valued magnitude-CSI we already have.
+
+2. **CIR-based delay spread** (alternative). Take the inverse FFT along
+   the subcarrier axis to get the channel impulse response; compute the
+   RMS delay spread; coherence bandwidth ≈ 1 / (5 · τ_RMS). Requires
+   complex CSI — not directly applicable to our magnitude projection,
+   so this estimator is provided for future use if the loader is
+   extended to keep complex CSI.
+
+For our default setup (30 subcarriers, magnitude-only CSI on Widar3.0),
+the autocorrelation estimator is the operative one.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def estimate_coherence_bandwidth_subcarriers(
+    x: torch.Tensor,
+    threshold: float = 0.5,
+    min_width: int = 1,
+    max_width: int | None = None,
+) -> int:
+    """Estimate coherence bandwidth in *number of subcarriers*.
+
+    Args:
+        x: real-valued CSI shaped `(T, S, A)` or `(B, T, S, A)`. The
+            estimator averages over time and antennas (and batch, if
+            present) before computing the autocorrelation, so the
+            returned scalar is a dataset-wide estimate.
+        threshold: lag-correlation threshold defining "still coherent."
+            Default 0.5 matches the convention used in coherence-bandwidth
+            literature; some texts use 0.9 for tighter coherence.
+        min_width: minimum returned width. Defaults to 1 (no smaller
+            block makes sense for masking).
+        max_width: optional cap. Defaults to `S // 2` — beyond that,
+            "coherent block" loses meaning.
+
+    Returns:
+        Integer coherence-bandwidth width in subcarriers.
+    """
+    if x.ndim == 3:
+        x = x.unsqueeze(0)  # (1, T, S, A)
+    if x.ndim != 4:
+        raise ValueError(f"expected (T, S, A) or (B, T, S, A); got ndim={x.ndim}")
+    b, t, s, a = x.shape
+    if max_width is None:
+        max_width = s // 2
+
+    # Flatten batch/time/antennas; treat each as one realization.
+    # Demean over the subcarrier axis to compute correlation, not covariance.
+    flat = x.permute(0, 1, 3, 2).reshape(b * t * a, s)
+    flat = flat - flat.mean(dim=1, keepdim=True)
+
+    # Variance per realization
+    raw_var = (flat * flat).mean(dim=1)
+    var = raw_var + 1e-12
+
+    # Edge case: if the input is essentially constant along the subcarrier
+    # axis (degenerate "perfectly coherent" case), every lag stays at full
+    # correlation by definition. Return max_width directly.
+    if raw_var.mean().item() < 1e-10:
+        return max(min_width, max_width)
+
+    # Autocorrelation at each lag in [0, max_width].
+    auto = []
+    for lag in range(0, max_width + 1):
+        if lag == 0:
+            corr = torch.ones(flat.shape[0], dtype=flat.dtype, device=flat.device)
+        else:
+            corr = (flat[:, :-lag] * flat[:, lag:]).mean(dim=1) / var
+        auto.append(corr.mean().item())
+
+    # Find the smallest lag where autocorrelation drops below threshold.
+    for lag, value in enumerate(auto):
+        if lag == 0:
+            continue
+        if value < threshold:
+            return max(min_width, lag)
+    return max(min_width, max_width)
+
+
+def autocorrelation_curve(
+    x: torch.Tensor,
+    max_lag: int | None = None,
+) -> torch.Tensor:
+    """Return the average lagged autocorrelation as a 1-D tensor of length `max_lag + 1`.
+
+    Useful for diagnostic plots in T4.6 and the per-slice writeup. lag=0
+    is always 1.0 by construction.
+    """
+    if x.ndim == 3:
+        x = x.unsqueeze(0)
+    if x.ndim != 4:
+        raise ValueError(f"expected (T, S, A) or (B, T, S, A); got ndim={x.ndim}")
+    b, t, s, a = x.shape
+    if max_lag is None:
+        max_lag = s - 1
+    flat = x.permute(0, 1, 3, 2).reshape(b * t * a, s)
+    flat = flat - flat.mean(dim=1, keepdim=True)
+    var = (flat * flat).mean(dim=1) + 1e-12
+
+    curve = torch.zeros(max_lag + 1, dtype=flat.dtype)
+    curve[0] = 1.0
+    for lag in range(1, max_lag + 1):
+        corr = (flat[:, :-lag] * flat[:, lag:]).mean(dim=1) / var
+        curve[lag] = corr.mean().item()
+    return curve

--- a/src/slices/ihunanya/robustness.py
+++ b/src/slices/ihunanya/robustness.py
@@ -1,0 +1,96 @@
+"""Held-out subcarrier robustness sweep for Slice 4 (T4.6).
+
+The slice's distinctive contribution to the team paper. After training
+(supervised or SSL), evaluate the model on the test set while randomly
+masking N of the S subcarriers at test time. Sweep N from 0 (no masking)
+upward; plot accuracy vs N for the hand-crafted baseline and for the
+coherence-aware-mask augmentation. A coherence-aware encoder should
+degrade more gracefully — that's the claim.
+
+This is the source of `papers/team/coherence-robustness-figure.png`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import numpy as np
+import torch
+from sklearn.linear_model import LogisticRegression
+from torch import nn
+from torch.utils.data import DataLoader
+
+from .encoder import reshape_csi_for_encoder
+
+
+@torch.no_grad()
+def _extract_features(
+    encoder: nn.Module,
+    loader: DataLoader,
+    *,
+    device: str,
+    test_mask_n: int = 0,
+    test_mask_seed: int | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Same as `eval.extract_features` but applies a random subcarrier mask of
+    width `test_mask_n` to every input batch first (zero-out, contiguous
+    region per batch). Used for the robustness sweep.
+    """
+    encoder.eval()
+    encoder.to(device)
+    features: list[np.ndarray] = []
+    labels: list[np.ndarray] = []
+    g = torch.Generator(device="cpu")
+    if test_mask_seed is not None:
+        g.manual_seed(test_mask_seed)
+    for batch in loader:
+        x, y = batch
+        x = x.to(device).float()
+        if test_mask_n > 0:
+            s = x.shape[-2]
+            max_start = max(0, s - test_mask_n)
+            start = int(torch.randint(0, max_start + 1, (1,), generator=g).item())
+            x = x.clone()
+            x[..., start : start + test_mask_n, :] = 0
+        x = reshape_csi_for_encoder(x)
+        h = encoder(x)
+        features.append(h.cpu().numpy())
+        labels.append(np.asarray(y))
+    return np.concatenate(features, axis=0), np.concatenate(labels, axis=0)
+
+
+def robustness_sweep(
+    encoder: nn.Module,
+    train_loader: DataLoader,
+    test_loader: DataLoader,
+    *,
+    mask_widths: Iterable[int],
+    device: str = "cpu",
+    seed: int = 42,
+) -> dict[int, float]:
+    """Sweep test-time subcarrier-mask widths; return {width: accuracy}.
+
+    Fits a linear classifier on the (un-masked) training features so the
+    classifier is fair across mask widths; only the test-time features
+    are perturbed. This isolates "is the encoder's representation robust
+    to test-time subcarrier dropout?" from "did the classifier learn
+    something brittle?".
+    """
+    train_x, train_y = _extract_features(
+        encoder, train_loader, device=device, test_mask_n=0
+    )
+    clf = LogisticRegression(max_iter=1000, random_state=seed)
+    clf.fit(train_x, train_y)
+
+    out: dict[int, float] = {}
+    for n in mask_widths:
+        test_x, test_y = _extract_features(
+            encoder,
+            test_loader,
+            device=device,
+            test_mask_n=int(n),
+            test_mask_seed=seed + int(n),
+        )
+        pred = clf.predict(test_x)
+        out[int(n)] = float(np.mean(pred == test_y))
+    return out

--- a/src/slices/ihunanya/run.py
+++ b/src/slices/ihunanya/run.py
@@ -1,12 +1,21 @@
-"""End-to-end smoke run for Slice 4 (T4.1).
+"""End-to-end run for Slice 4.
 
-Wires StubCSI -> TinyCNN encoder -> SimCLR pre-training (no aug) ->
-linear-probe eval. T4.1 only proves the pipeline runs; T4.3 will add the
-coherence-bandwidth estimation, T4.5 the coherence-aware subcarrier masking
-augmentation that this slice's actual contribution is.
+Three modes via `--mode`:
+
+- `simclr-none` (T4.1): no augmentation, plumbing only.
+- `simclr-handcrafted` (the comparison baseline): Gaussian + random
+  subcarrier mask.
+- `simclr-coherent-mask` (T4.5, ours): contiguous block of width
+  ≈ coherence bandwidth, estimated from the pre-training data.
+
+`--sweep` adds the held-out-subcarrier robustness sweep (T4.6) after
+pre-training and linear probe.
 
 Run:
-    python -m src.slices.ihunanya.run
+    python -m src.slices.ihunanya.run                              # plumbing
+    python -m src.slices.ihunanya.run --mode simclr-handcrafted    # baseline
+    python -m src.slices.ihunanya.run --mode simclr-coherent-mask  # ours
+    python -m src.slices.ihunanya.run --mode simclr-coherent-mask --sweep
 """
 
 from __future__ import annotations
@@ -18,9 +27,12 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
+from .augmentations import coherent_block_mask, gaussian_then_mask
+from .coherence import estimate_coherence_bandwidth_subcarriers
 from .data import CSI_A, CSI_S, NUM_CLASSES, StubCSI
 from .encoder import TinyCNN, count_parameters
 from .eval import linear_probe
+from .robustness import robustness_sweep
 from .ssl import SimCLR, pretrain_simclr
 
 
@@ -30,10 +42,35 @@ def set_seed(seed: int) -> None:
     torch.manual_seed(seed)
 
 
+def _build_aug(mode: str, block_width: int):
+    if mode == "simclr-none":
+        return None
+    if mode == "simclr-handcrafted":
+        return gaussian_then_mask
+    if mode == "simclr-coherent-mask":
+
+        def _aug(x: torch.Tensor) -> torch.Tensor:
+            return coherent_block_mask(x, block_width=block_width)
+
+        _aug.__name__ = f"coherent_block_mask_w{block_width}"
+        return _aug
+    raise ValueError(f"unknown mode: {mode!r}")
+
+
+_MODE_TAGS = {
+    "simclr-none": "T4.1",
+    "simclr-handcrafted": "T4.6 (baseline)",
+    "simclr-coherent-mask": "T4.5 (ours)",
+}
+
+
 def main(
+    mode: str = "simclr-none",
     seed: int = 42,
     epochs: int = 2,
     batch_size: int = 4,
+    sweep: bool = False,
+    sweep_widths: list[int] | None = None,
 ) -> float:
     set_seed(seed)
     device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -42,7 +79,10 @@ def main(
     train_ds = StubCSI(num_samples=10, seed=seed + 1)
     test_ds = StubCSI(num_samples=10, seed=seed + 2)
 
-    # drop_last=True so a singleton SimCLR batch doesn't collapse NT-Xent.
+    sample_for_estimate = torch.stack([pretrain_ds[i][0] for i in range(len(pretrain_ds))])
+    coh_bw = estimate_coherence_bandwidth_subcarriers(sample_for_estimate)
+    print(f"[ihunanya] estimated coherence bandwidth: {coh_bw} subcarriers")
+
     pretrain_loader = DataLoader(
         pretrain_ds, batch_size=batch_size, shuffle=True, drop_last=True
     )
@@ -50,38 +90,61 @@ def main(
     test_loader = DataLoader(test_ds, batch_size=batch_size, shuffle=False)
 
     encoder = TinyCNN(in_channels=CSI_S * CSI_A, feature_dim=128)
-    print(f"[T4.1] encoder params: {count_parameters(encoder)}")
+    tag = _MODE_TAGS[mode]
+    print(f"[{tag}] encoder params: {count_parameters(encoder)}")
 
     model = SimCLR(encoder, feature_dim=128, projection_dim=64)
+    augment_fn = _build_aug(mode, block_width=coh_bw)
     losses = pretrain_simclr(
         model,
         pretrain_loader,
         epochs=epochs,
         lr=1e-3,
         temperature=0.5,
-        augment_fn=None,  # T4.5 will plug in the static-perturbation aug
+        augment_fn=augment_fn,
         device=device,
     )
-    print(f"[T4.1] pre-train losses: {[round(loss, 4) for loss in losses]}")
+    print(f"[{tag}] pre-train losses: {[round(loss, 4) for loss in losses]}")
 
     acc = linear_probe(
         model.encoder, train_loader, test_loader, device=device, seed=seed
     )
-    chance = 1.0 / NUM_CLASSES
     print(
-        f"[T4.1] linear-probe accuracy on stub data: {acc:.3f} (chance ~ {chance:.3f})"
+        f"[{tag}] linear-probe accuracy: {acc:.3f} (chance ~ {1 / NUM_CLASSES:.3f})"
     )
+
+    if sweep:
+        widths = sweep_widths or [0, 2, 5, 10, 15]
+        print(f"[T4.6 robustness sweep] mask widths: {widths}")
+        sweep_results = robustness_sweep(
+            model.encoder,
+            train_loader,
+            test_loader,
+            mask_widths=widths,
+            device=device,
+            seed=seed,
+        )
+        for n, sweep_acc in sweep_results.items():
+            print(f"[T4.6 robustness sweep] mask={n:>3d}: acc={sweep_acc:.3f}")
     return acc
 
 
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser()
+    p.add_argument("--mode", choices=sorted(_MODE_TAGS), default="simclr-none")
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--epochs", type=int, default=2)
     p.add_argument("--batch-size", type=int, default=4)
+    p.add_argument("--sweep", action="store_true", help="Run T4.6 robustness sweep")
     return p.parse_args()
 
 
 if __name__ == "__main__":
     args = _parse_args()
-    main(seed=args.seed, epochs=args.epochs, batch_size=args.batch_size)
+    main(
+        mode=args.mode,
+        seed=args.seed,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        sweep=args.sweep,
+    )

--- a/tests/slices/ihunanya/test_coherence.py
+++ b/tests/slices/ihunanya/test_coherence.py
@@ -1,0 +1,96 @@
+"""Unit tests for Slice 4's coherence-bandwidth and coherent-block-mask (T4.3, T4.4, T4.5).
+
+T4.4 is the sanity test: a synthetic two-tap channel with a known delay
+spread should produce a coherence-bandwidth estimate that lands in the
+expected band.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.slices.ihunanya.augmentations import coherent_block_mask
+from src.slices.ihunanya.coherence import (
+    autocorrelation_curve,
+    estimate_coherence_bandwidth_subcarriers,
+)
+
+
+def test_perfectly_flat_subcarriers_give_max_coherence() -> None:
+    """If all subcarriers are identical, coherence bandwidth = max width."""
+    # x: (T, S, A) = (10, 30, 3). All subcarriers equal a single time signal.
+    base = torch.randn(10, 1, 3)
+    x = base.expand(10, 30, 3).clone()
+    bw = estimate_coherence_bandwidth_subcarriers(x, threshold=0.5)
+    # With perfect correlation, the threshold is never crossed; returns max_width.
+    assert bw == 30 // 2
+
+
+def test_independent_subcarriers_give_min_coherence() -> None:
+    """If subcarriers are independent random noise, coherence drops immediately."""
+    torch.manual_seed(0)
+    x = torch.randn(50, 30, 3)
+    bw = estimate_coherence_bandwidth_subcarriers(x, threshold=0.5)
+    # Lag-1 autocorrelation of i.i.d. noise is ~0; threshold 0.5 fails at lag 1.
+    assert bw == 1
+
+
+def test_partial_correlation_gives_intermediate_coherence() -> None:
+    """A signal with gradual correlation should land between 1 and max."""
+    # Construct an AR(1) signal across the subcarrier axis: each subcarrier
+    # is a noisy version of the previous. The autocorrelation decays
+    # geometrically with the AR coefficient.
+    torch.manual_seed(0)
+    rho = 0.9
+    s = 30
+    x_s = torch.zeros(20, s, 3)
+    x_s[:, 0, :] = torch.randn(20, 3)
+    for k in range(1, s):
+        x_s[:, k, :] = rho * x_s[:, k - 1, :] + (1 - rho) * torch.randn(20, 3)
+    bw = estimate_coherence_bandwidth_subcarriers(x_s, threshold=0.5)
+    # AR(1) with rho=0.9: autocorr drops below 0.5 around lag log(0.5)/log(0.9) ≈ 6.6
+    assert 3 <= bw <= 10, f"expected ~6 subcarriers, got {bw}"
+
+
+def test_autocorrelation_curve_starts_at_one() -> None:
+    x = torch.randn(10, 30, 3)
+    curve = autocorrelation_curve(x, max_lag=10)
+    assert curve.shape == (11,)
+    assert abs(curve[0].item() - 1.0) < 1e-5
+
+
+def test_coherent_block_mask_zeros_contiguous_subcarriers() -> None:
+    torch.manual_seed(0)
+    x = torch.ones(2, 10, 30, 3)
+    out = coherent_block_mask(x, block_width=5)
+    assert out.shape == x.shape
+    # Per sample, exactly 5 contiguous subcarriers should be zero.
+    for i in range(2):
+        zero_mask = (out[i].amax(dim=(0, 2)) == 0).int()  # (S,)
+        assert (
+            int(zero_mask.sum()) == 5
+        ), f"sample {i}: expected 5 zeros, got {int(zero_mask.sum())}"
+        # And they should be contiguous.
+        idx = torch.where(zero_mask == 1)[0]
+        assert int(idx[-1] - idx[0]) == 4
+
+
+def test_coherent_block_mask_two_calls_differ() -> None:
+    """Two independent calls should mask different subcarrier ranges."""
+    torch.manual_seed(0)
+    x = torch.ones(4, 10, 30, 3)
+    v1 = coherent_block_mask(x, block_width=5)
+    v2 = coherent_block_mask(x, block_width=5)
+    assert not torch.equal(v1, v2)
+
+
+def test_coherent_block_mask_passthrough_when_zero_width() -> None:
+    x = torch.randn(2, 10, 30, 3)
+    out = coherent_block_mask(x, block_width=0)
+    assert torch.equal(out, x)
+
+
+def test_coherent_block_mask_rejects_garbage_shape() -> None:
+    with pytest.raises(ValueError):
+        coherent_block_mask(torch.zeros(30, 3), block_width=5)


### PR DESCRIPTION
## Summary

Slice 4 (ihunanya) tracer-bullets T4.3, T4.5, T4.6.

- **T4.3 coherence-bandwidth estimation** (\`coherence.py\`) — lagged subcarrier autocorrelation with threshold 0.5. Degenerate constant-input case short-circuits to \`max_width\`.
- **T4.5 coherent block-mask aug** (\`augmentations.py\`) — zeros a contiguous block of width=coherence-bw at a per-sample random start. Plus the hand-crafted gaussian+random-mask baseline for the \`simclr-handcrafted\` comparison column.
- **T4.6 held-out subcarrier robustness sweep** (\`robustness.py\`) — fits LR on unmasked train features; evaluates test features with contiguous masks of varying widths. This is the source of the team paper's \`coherence-robustness-figure\`.
- **\`run.py\`** — \`--mode {simclr-none, simclr-handcrafted, simclr-coherent-mask}\` and \`--sweep\` flag.

## Test plan

- [x] \`pytest tests/slices/ihunanya/\` — 13 passing (AR(1) sanity, degenerate cases, mask contiguity/passthrough).
- [x] \`python -m src.slices.ihunanya.run --mode simclr-coherent-mask --sweep\` — green end-to-end on StubCSI.
- [ ] Real-data sweep on Widar3.0 (post-merge; same pattern as T5.6 smoke).