### PR TITLE
T6.3: in-slice Doppler + coherence-mask reimplementations

### DIFF
--- a/src/slices/victor/README.md
+++ b/src/slices/victor/README.md
@@ -2,7 +2,7 @@
 
 Per `docs/08-team-work-plan.md` §5 and `docs/09-execution-roadmap.md` §2.2.
 
-**Theme.** Decompose a raw-CSI sample into a *static* component (the slowly-varying contribution from walls, furniture, ceiling — the room) and a *dynamic* component (the fast-varying contribution from the moving person). Replace the static component with one from a different sample to simulate "the same activity in a different room." Tested on cross-subject + interaction term, the most direct test of room-invariance.
+**Theme.** Do physics-informed augmentation effects compose linearly? The deck flags "isolating effects" as a difficulty. This slice tests it directly using **Doppler-aware time warping + coherence-aware subcarrier masking** — two of the four physics-informed augmentations, operating on orthogonal axes (time and frequency), both reimplemented in this slice's directory for full independence from Slices 1 and 4.
 
 Run the smoke test:
 

--- a/src/slices/victor/augmentations.py
+++ b/src/slices/victor/augmentations.py
@@ -1,0 +1,161 @@
+"""Augmentations for Slice 6 (composability of Doppler + coherence-mask).
+
+T6.3 reimplements both physics-informed augmentations from scratch
+in-slice so this slice is independent of Slices 1 and 4:
+
+- `doppler_warp`: time-axis stretch by a random factor in [0.7, 1.4].
+  Activity speed scales the Doppler component of CSI approximately
+  linearly; warping time simulates the same activity at a different
+  speed.
+- `coherent_block_mask`: zero a contiguous block of `block_width`
+  subcarriers at a random start. `block_width` is the coherence-bw
+  estimate from `coherence.py` — the block simulates a frequency-
+  selective fade where a coherent chunk of the spectrum drops out.
+
+Composition helpers (`doppler_then_coherent_mask` and
+`doppler_or_coherent_mask`) are the candidates the composability study
+(T6.5) uses to combine the two.
+
+Generic hand-crafted baseline (`gaussian_then_mask`) is included for the
+`simclr-handcrafted` comparison column.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+DEFAULT_FACTOR_RANGE = (0.7, 1.4)
+
+
+# ---------------------------------------------------------------------------
+# Doppler-aware time warping
+
+
+def _sample_factor(low: float, high: float) -> float:
+    return float(torch.empty(1).uniform_(low, high).item())
+
+
+def _doppler_warp_one(x: torch.Tensor, factor: float) -> torch.Tensor:
+    if x.ndim != 3:
+        raise ValueError(f"_doppler_warp_one expects (T, S, A); got {tuple(x.shape)}")
+    t, s, a = x.shape
+    t_new = max(1, int(round(t * factor)))
+    x_in = x.permute(1, 2, 0).reshape(1, s * a, t)
+    x_r = F.interpolate(x_in, size=t_new, mode="linear", align_corners=False)
+    x_r = x_r.reshape(s, a, t_new).permute(2, 0, 1)
+    if x_r.shape[0] >= t:
+        return x_r[:t]
+    pad = torch.zeros(t - x_r.shape[0], s, a, dtype=x.dtype, device=x.device)
+    return torch.cat([x_r, pad], dim=0)
+
+
+def doppler_warp(
+    x: torch.Tensor,
+    factor: float | None = None,
+    factor_range: tuple[float, float] = DEFAULT_FACTOR_RANGE,
+) -> torch.Tensor:
+    """Doppler-aware time warp.
+
+    Accepts `(T, S, A)` or `(B, T, S, A)`. If `factor` is None, each
+    sample gets an independent factor from `factor_range`.
+    """
+    low, high = factor_range
+    if x.ndim == 3:
+        f = _sample_factor(low, high) if factor is None else factor
+        return _doppler_warp_one(x, f)
+    if x.ndim == 4:
+        out = torch.empty_like(x)
+        for i in range(x.shape[0]):
+            f = _sample_factor(low, high) if factor is None else factor
+            out[i] = _doppler_warp_one(x[i], f)
+        return out
+    raise ValueError(
+        f"doppler_warp expects (T, S, A) or (B, T, S, A); got {tuple(x.shape)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Coherence-aware subcarrier masking
+
+
+def coherent_block_mask(
+    x: torch.Tensor,
+    block_width: int = 5,
+) -> torch.Tensor:
+    """Mask a contiguous block of `block_width` subcarriers at random start.
+
+    Accepts `(T, S, A)` or `(B, T, S, A)`.
+    """
+    if x.ndim not in (3, 4):
+        raise ValueError(f"expected (T, S, A) or (B, T, S, A); got ndim={x.ndim}")
+    s = x.shape[-2]
+    if block_width <= 0:
+        return x
+    if block_width >= s:
+        block_width = s - 1
+    max_start = s - block_width
+
+    if x.ndim == 3:
+        start = int(torch.randint(0, max_start + 1, (1,)).item())
+        out = x.clone()
+        out[:, start : start + block_width, :] = 0
+        return out
+
+    b = x.shape[0]
+    starts = torch.randint(0, max_start + 1, (b,), device=x.device)
+    out = x.clone()
+    for i in range(b):
+        s_i = int(starts[i].item())
+        out[i, :, s_i : s_i + block_width, :] = 0
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Composition strategies for T6.5
+
+
+def doppler_then_coherent_mask(
+    x: torch.Tensor,
+    block_width: int = 5,
+    factor_range: tuple[float, float] = DEFAULT_FACTOR_RANGE,
+) -> torch.Tensor:
+    """Sequential composition: Doppler warp, then coherent block mask.
+
+    Both transformations applied to the same view. This is the "do they
+    compose" candidate the composability study compares against the
+    individual augmentations.
+    """
+    return coherent_block_mask(
+        doppler_warp(x, factor_range=factor_range),
+        block_width=block_width,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hand-crafted baseline (same as Slices 1 / 4 / 5)
+
+
+def gaussian_noise(x: torch.Tensor, sigma: float = 0.05) -> torch.Tensor:
+    return x + torch.randn_like(x) * sigma
+
+
+def random_subcarrier_mask(x: torch.Tensor, p: float = 0.15) -> torch.Tensor:
+    if x.ndim == 3:
+        s = x.shape[1]
+        keep = torch.rand(s, device=x.device) >= p
+        return x * keep.view(1, s, 1).to(x.dtype)
+    if x.ndim == 4:
+        b, _, s, _ = x.shape
+        keep = torch.rand(b, s, device=x.device) >= p
+        return x * keep.view(b, 1, s, 1).to(x.dtype)
+    raise ValueError(
+        f"random_subcarrier_mask expects (T, S, A) or (B, T, S, A); "
+        f"got {tuple(x.shape)}"
+    )
+
+
+def gaussian_then_mask(
+    x: torch.Tensor, sigma: float = 0.05, p: float = 0.15
+) -> torch.Tensor:
+    return random_subcarrier_mask(gaussian_noise(x, sigma=sigma), p=p)

--- a/src/slices/victor/coherence.py
+++ b/src/slices/victor/coherence.py
@@ -1,0 +1,61 @@
+"""Coherence-bandwidth estimation for Slice 6 (T6.3 prerequisite).
+
+In-slice reimplementation of the coherence-bandwidth estimator. The
+composability slice needs its own copy so it's independent of Slice 4 —
+no cross-slice imports per repo convention.
+
+Estimator: lagged subcarrier autocorrelation. For each sample, compute
+the correlation between subcarrier `k` and subcarrier `k+lag` along the
+subcarrier axis, averaged over time / antennas / batch. The smallest
+lag at which the average autocorrelation falls below `threshold`
+(default 0.5) is the coherence bandwidth, expressed in number of
+subcarriers — the integer width of a "still coherent" block on our
+30-subcarrier grid.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def estimate_coherence_bandwidth_subcarriers(
+    x: torch.Tensor,
+    threshold: float = 0.5,
+    min_width: int = 1,
+    max_width: int | None = None,
+) -> int:
+    """Estimate coherence bandwidth in *number of subcarriers*.
+
+    Args:
+        x: real-valued CSI shaped `(T, S, A)` or `(B, T, S, A)`.
+        threshold: lag-correlation threshold defining "still coherent."
+        min_width: minimum returned width (default 1).
+        max_width: optional cap (default `S // 2`).
+
+    Returns:
+        Integer coherence-bandwidth width in subcarriers.
+    """
+    if x.ndim == 3:
+        x = x.unsqueeze(0)
+    if x.ndim != 4:
+        raise ValueError(f"expected (T, S, A) or (B, T, S, A); got ndim={x.ndim}")
+    b, t, s, a = x.shape
+    if max_width is None:
+        max_width = s // 2
+
+    flat = x.permute(0, 1, 3, 2).reshape(b * t * a, s)
+    flat = flat - flat.mean(dim=1, keepdim=True)
+
+    raw_var = (flat * flat).mean(dim=1)
+    var = raw_var + 1e-12
+
+    # Degenerate "perfectly coherent" input (constant along subcarrier axis):
+    # every lag stays at full correlation by definition. Return max_width.
+    if raw_var.mean().item() < 1e-10:
+        return max(min_width, max_width)
+
+    for lag in range(1, max_width + 1):
+        corr = (flat[:, :-lag] * flat[:, lag:]).mean(dim=1) / var
+        if corr.mean().item() < threshold:
+            return max(min_width, lag)
+    return max(min_width, max_width)

--- a/src/slices/victor/run.py
+++ b/src/slices/victor/run.py
@@ -1,12 +1,24 @@
-"""End-to-end smoke run for Slice 6 (T6.1).
+"""End-to-end run for Slice 6 (composability of Doppler + coherence-mask).
 
-Wires StubCSI -> TinyCNN encoder -> SimCLR pre-training (no aug) ->
-linear-probe eval. T6.1 only proves the pipeline runs; T6.3 will add the
-reimplementation of Doppler + coherence-mask, T6.5 the composability study
-augmentation that this slice's actual contribution is.
+Modes via `--mode`:
+
+- `simclr-none` (T6.1): no augmentation, plumbing only.
+- `simclr-handcrafted` (baseline): Gaussian + random subcarrier mask.
+- `simclr-doppler` (T6.3): Doppler time warp alone.
+- `simclr-coherent-mask` (T6.3): coherent block mask alone, width
+  estimated from the pre-training data.
+- `simclr-combined` (T6.5): Doppler then coherent mask, sequential
+  composition on the same view.
+
+The composability study (T6.5–T6.6) runs the four non-`none` modes and
+computes the interaction term `combined - (doppler + coherent_mask)`.
 
 Run:
-    python -m src.slices.victor.run
+    python -m src.slices.victor.run                              # plumbing
+    python -m src.slices.victor.run --mode simclr-handcrafted
+    python -m src.slices.victor.run --mode simclr-doppler
+    python -m src.slices.victor.run --mode simclr-coherent-mask
+    python -m src.slices.victor.run --mode simclr-combined
 """
 
 from __future__ import annotations
@@ -18,6 +30,13 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
+from .augmentations import (
+    coherent_block_mask,
+    doppler_then_coherent_mask,
+    doppler_warp,
+    gaussian_then_mask,
+)
+from .coherence import estimate_coherence_bandwidth_subcarriers
 from .data import CSI_A, CSI_S, NUM_CLASSES, StubCSI
 from .encoder import TinyCNN, count_parameters
 from .eval import linear_probe
@@ -30,7 +49,41 @@ def set_seed(seed: int) -> None:
     torch.manual_seed(seed)
 
 
+_MODE_TAGS = {
+    "simclr-none": "T6.1",
+    "simclr-handcrafted": "T6.6 (baseline)",
+    "simclr-doppler": "T6.4 (doppler)",
+    "simclr-coherent-mask": "T6.4 (coh-mask)",
+    "simclr-combined": "T6.5 (combined)",
+}
+
+
+def _build_aug(mode: str, block_width: int):
+    if mode == "simclr-none":
+        return None
+    if mode == "simclr-handcrafted":
+        return gaussian_then_mask
+    if mode == "simclr-doppler":
+        return doppler_warp
+    if mode == "simclr-coherent-mask":
+
+        def _aug(x: torch.Tensor) -> torch.Tensor:
+            return coherent_block_mask(x, block_width=block_width)
+
+        _aug.__name__ = f"coherent_block_mask_w{block_width}"
+        return _aug
+    if mode == "simclr-combined":
+
+        def _aug(x: torch.Tensor) -> torch.Tensor:
+            return doppler_then_coherent_mask(x, block_width=block_width)
+
+        _aug.__name__ = f"doppler_then_coherent_mask_w{block_width}"
+        return _aug
+    raise ValueError(f"unknown mode: {mode!r}")
+
+
 def main(
+    mode: str = "simclr-none",
     seed: int = 42,
     epochs: int = 2,
     batch_size: int = 4,
@@ -42,7 +95,10 @@ def main(
     train_ds = StubCSI(num_samples=10, seed=seed + 1)
     test_ds = StubCSI(num_samples=10, seed=seed + 2)
 
-    # drop_last=True so a singleton SimCLR batch doesn't collapse NT-Xent.
+    sample_for_estimate = torch.stack([pretrain_ds[i][0] for i in range(len(pretrain_ds))])
+    coh_bw = estimate_coherence_bandwidth_subcarriers(sample_for_estimate)
+    print(f"[victor] estimated coherence bandwidth: {coh_bw} subcarriers")
+
     pretrain_loader = DataLoader(
         pretrain_ds, batch_size=batch_size, shuffle=True, drop_last=True
     )
@@ -50,32 +106,34 @@ def main(
     test_loader = DataLoader(test_ds, batch_size=batch_size, shuffle=False)
 
     encoder = TinyCNN(in_channels=CSI_S * CSI_A, feature_dim=128)
-    print(f"[T6.1] encoder params: {count_parameters(encoder)}")
+    tag = _MODE_TAGS[mode]
+    print(f"[{tag}] encoder params: {count_parameters(encoder)}")
 
     model = SimCLR(encoder, feature_dim=128, projection_dim=64)
+    augment_fn = _build_aug(mode, block_width=coh_bw)
     losses = pretrain_simclr(
         model,
         pretrain_loader,
         epochs=epochs,
         lr=1e-3,
         temperature=0.5,
-        augment_fn=None,  # T6.5 will plug in the static-perturbation aug
+        augment_fn=augment_fn,
         device=device,
     )
-    print(f"[T6.1] pre-train losses: {[round(loss, 4) for loss in losses]}")
+    print(f"[{tag}] pre-train losses: {[round(loss, 4) for loss in losses]}")
 
     acc = linear_probe(
         model.encoder, train_loader, test_loader, device=device, seed=seed
     )
-    chance = 1.0 / NUM_CLASSES
     print(
-        f"[T6.1] linear-probe accuracy on stub data: {acc:.3f} (chance ~ {chance:.3f})"
+        f"[{tag}] linear-probe accuracy: {acc:.3f} (chance ~ {1 / NUM_CLASSES:.3f})"
     )
     return acc
 
 
 def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser()
+    p.add_argument("--mode", choices=sorted(_MODE_TAGS), default="simclr-none")
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--epochs", type=int, default=2)
     p.add_argument("--batch-size", type=int, default=4)
@@ -84,4 +142,9 @@ def _parse_args() -> argparse.Namespace:
 
 if __name__ == "__main__":
     args = _parse_args()
-    main(seed=args.seed, epochs=args.epochs, batch_size=args.batch_size)
+    main(
+        mode=args.mode,
+        seed=args.seed,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+    )

--- a/tests/slices/victor/test_augmentations.py
+++ b/tests/slices/victor/test_augmentations.py
@@ -1,0 +1,96 @@
+"""Tests for Slice 6 in-slice augmentation reimplementations (T6.3).
+
+These mirror the spirit of the Slice 1 (Doppler) and Slice 4
+(coherent-mask) tests but exercise this slice's local copies — the
+point of T6.3 is that the reimplementations are independent.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from src.slices.victor.augmentations import (
+    coherent_block_mask,
+    doppler_then_coherent_mask,
+    doppler_warp,
+)
+from src.slices.victor.coherence import estimate_coherence_bandwidth_subcarriers
+
+
+# --- Doppler -------------------------------------------------------------
+
+
+def test_doppler_warp_preserves_shape_single() -> None:
+    x = torch.randn(10, 30, 3)
+    out = doppler_warp(x, factor=0.8)
+    assert out.shape == x.shape
+
+
+def test_doppler_warp_preserves_shape_batch() -> None:
+    x = torch.randn(4, 10, 30, 3)
+    out = doppler_warp(x, factor=1.2)
+    assert out.shape == x.shape
+
+
+def test_doppler_warp_two_calls_differ() -> None:
+    torch.manual_seed(0)
+    x = torch.randn(4, 10, 30, 3)
+    v1 = doppler_warp(x)
+    v2 = doppler_warp(x)
+    assert not torch.equal(v1, v2)
+
+
+def test_doppler_warp_rejects_garbage_shape() -> None:
+    with pytest.raises(ValueError):
+        doppler_warp(torch.zeros(30, 3))
+
+
+# --- Coherence bandwidth + coherent mask ---------------------------------
+
+
+def test_coherence_independent_subcarriers() -> None:
+    torch.manual_seed(0)
+    x = torch.randn(50, 30, 3)
+    bw = estimate_coherence_bandwidth_subcarriers(x, threshold=0.5)
+    assert bw == 1
+
+
+def test_coherent_block_mask_zeros_contiguous() -> None:
+    torch.manual_seed(0)
+    x = torch.ones(2, 10, 30, 3)
+    out = coherent_block_mask(x, block_width=5)
+    assert out.shape == x.shape
+    for i in range(2):
+        zero_mask = (out[i].amax(dim=(0, 2)) == 0).int()
+        assert int(zero_mask.sum()) == 5
+        idx = torch.where(zero_mask == 1)[0]
+        assert int(idx[-1] - idx[0]) == 4
+
+
+def test_coherent_block_mask_passthrough_when_zero_width() -> None:
+    x = torch.randn(2, 10, 30, 3)
+    out = coherent_block_mask(x, block_width=0)
+    assert torch.equal(out, x)
+
+
+# --- Composition ---------------------------------------------------------
+
+
+def test_doppler_then_coherent_mask_shape() -> None:
+    x = torch.randn(4, 10, 30, 3)
+    out = doppler_then_coherent_mask(x, block_width=5)
+    assert out.shape == x.shape
+
+
+def test_doppler_then_coherent_mask_actually_masks() -> None:
+    """Composition should still zero out a contiguous subcarrier block."""
+    torch.manual_seed(0)
+    x = torch.ones(2, 10, 30, 3)
+    out = doppler_then_coherent_mask(x, block_width=5)
+    # Each sample must have at least 5 fully-zero subcarriers (Doppler warp
+    # on a constant signal stays constant within the support region, so the
+    # masked subcarriers stay exactly zero).
+    for i in range(2):
+        zero_count = int((out[i].amax(dim=(0, 2)) == 0).sum())
+        assert zero_count >= 5, f"sample {i}: expected >=5 zeros, got {zero_count}"


### PR DESCRIPTION
## Summary

Slice 6 (victor) tracer-bullet T6.3. Reimplements Doppler-aware time warping and coherence-aware subcarrier masking *in-slice* so Slice 6 is fully independent of Slices 1 and 4.

- \`coherence.py\` — lagged-autocorrelation coherence-bandwidth estimator (threshold 0.5).
- \`augmentations.py\` — \`doppler_warp\`, \`coherent_block_mask\`, and the T6.5 composition candidate \`doppler_then_coherent_mask\`. Plus the hand-crafted baseline for the comparison column.
- \`run.py\` — \`--mode {simclr-none, simclr-handcrafted, simclr-doppler, simclr-coherent-mask, simclr-combined}\`.
- \`README.md\` — restore the composability theme blurb (scaffold had inherited Slice 2's wording from the sed-template).

## Test plan

- [x] \`pytest tests/slices/victor/\` — 14 passing.
- [x] \`python -m src.slices.victor.run --mode simclr-combined\` — green end-to-end.
- [ ] Real-data cross-subject runs across all four non-\`none\` modes (T6.4–T6.5, follow-up PRs).