### PR TITLE
T5.4: AutoFi exact reproduction (Yang et al. 2022)

### DIFF
--- a/src/slices/josiah/README.md
+++ b/src/slices/josiah/README.md
@@ -22,7 +22,7 @@ The printed accuracy after T5.1 is at chance level — stub data has random labe
 
 1. **T5.2** — Supervised, no SSL. Real cross-subject data, 3 seeds.
 2. **T5.3** — SimCLR with trivial augmentation (random crop only).
-3. **T5.4** — Exact AutoFi reproduction (their CNN-LSTM, their pretext, their schedule).
+3. **T5.4** — Exact AutoFi reproduction (Yang et al. 2022). 6-layer Conv2d (Table I), twin GSS branches, L = L_p + λL_m + γL_g with λ=1, γ=1000 (eq. 9), SGD lr=0.01 momentum 0.9 for 300 epochs. Module: `autofi.py`. Run: `python -m src.slices.josiah.run --mode autofi`.
 4. **T5.5** — Exact CAPC reproduction (their encoder, their CPC + Barlow Twins setup).
 5. **T5.6** — Hand-crafted-aug SimCLR (Gaussian noise + random subcarrier mask). **The comparison column for slices 1, 2, 4, 6.**
 

--- a/src/slices/josiah/autofi.py
+++ b/src/slices/josiah/autofi.py
@@ -1,0 +1,268 @@
+"""AutoFi exact reproduction (T5.4).
+
+Geometric Self-Supervised Learning (GSS) from Yang et al.,
+"AutoFi: Towards Automatic WiFi Human Sensing via Geometric
+Self-Supervised Learning" (IEEE IoT Journal 2022).
+
+This module reproduces the GSS pre-training stage exactly as described
+in §III.B of the paper:
+
+- Augmentation A_ε: x ← x + εζ, ζ ~ N(0, σ²) — additive Gaussian noise
+  on the raw CSI (the paper's only augmentation).
+- Twin encoders E_θ1, E_θ2 (Table I 6-layer CNN) + non-linear heads
+  G_φ1, G_φ2 (MLP) that emit per-view prediction distributions P1, P2
+  over NUM_CLASSES bins via softmax.
+- Loss: L = L_p + λ·L_m + γ·L_g (eq. 9), λ=1, γ=1000.
+  - L_p (probability consistency, eq. 3): symmetric KL between P1, P2.
+  - L_m (mutual information, eq. 5): h(E[P]) + E[h(P)], applied to both
+    views and summed — note the paper writes the second term with a
+    plus sign because both terms are signed for *minimisation* of
+    -I(X;Y), see derivation in §III.B.
+  - L_g (geometric consistency, eq. 8): KL between cosine-similarity
+    Q-distributions of the two views (eqs. 6–7).
+- Optimiser: SGD, lr=0.01, momentum=0.9, batch 128, 300 epochs.
+
+Architecture (Table I, §III.B). The paper's stated input is
+3 × 114 × 500 (Atheros tool: 3 RX × 114 subcarriers × 500 timesteps).
+Widar3.0 with the Intel 5300 tool gives 3 RX × 30 subcarriers × T. The
+paper itself notes: "The first layer of the GSS module is slightly
+modified to match the input size." We follow the same adaptation: keep
+the layer-2..6 kernels exactly, scale down the layer-1 kernel and
+stride proportionally to the smaller subcarrier / time dimensions.
+
+The CSI tensor convention in this repo is (T, S, A); we permute to
+(A, S, T) before feeding the Conv2d stack — antennas as channels,
+subcarriers as height, time as width.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+
+
+# ---------------------------------------------------------------------------
+# Augmentation A_ε (eq. 1): additive Gaussian noise on subcarriers.
+
+def autofi_augment(x: torch.Tensor, sigma: float = 0.05) -> torch.Tensor:
+    """A_ε(x) = x + ε·ζ, ζ ~ N(0, σ²). The paper's only augmentation."""
+    return x + torch.randn_like(x) * sigma
+
+
+# ---------------------------------------------------------------------------
+# Feature extractor E_θ — 6-layer CNN, Table I.
+# Adapted for (A=3, S=30, T=100) Intel 5300 / Widar3.0 input.
+
+class AutoFiCNN(nn.Module):
+    """6-layer CNN from AutoFi Table I, adapted for 30-subcarrier input.
+
+    Output: (B, feature_dim) feature vector. The paper's classifier
+    F_ψ is a separate 128-then-6-dense head used in the few-shot
+    calibration stage (T5.4 doesn't run FSC; we just need E_θ).
+    """
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        s: int = 30,
+        t: int = 100,
+        feature_dim: int = 128,
+    ) -> None:
+        super().__init__()
+        # Table I exact kernels for layers 2..6. Layer 1 kernel/stride is
+        # scaled from (15,23)/9 to (5,9)/3 — same ~3:1 ratio between subcarrier
+        # and time kernel sizes, same stride-9 → stride-3 ratio (30/114 ≈ 0.26).
+        self.features = nn.Sequential(
+            nn.Conv2d(in_channels, 32, kernel_size=(5, 9), stride=3, padding=(2, 4)),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(32, 32, kernel_size=(3, 7), stride=1, padding=(1, 3)),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=(1, 2), stride=(1, 2)),
+            nn.Conv2d(32, 64, kernel_size=(3, 7), stride=1, padding=(1, 3)),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(64, 96, kernel_size=(3, 7), stride=1, padding=(1, 3)),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=(1, 2), stride=(1, 2)),
+        )
+
+        with torch.no_grad():
+            probe = torch.zeros(1, in_channels, s, t)
+            flat_dim = self.features(probe).flatten(1).shape[1]
+        self._flat_dim = flat_dim
+
+        self.proj = nn.Linear(flat_dim, feature_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Input (B, A, S, T); output (B, feature_dim)."""
+        h = self.features(x)
+        h = h.flatten(1)
+        return self.proj(h)
+
+
+# ---------------------------------------------------------------------------
+# Non-linear head G_φ (the "bottleneck layer" in §III.B that separates the
+# feature space). Two-layer MLP → softmax over NUM_CLASSES bins.
+
+class AutoFiHead(nn.Module):
+    def __init__(
+        self, feature_dim: int = 128, hidden_dim: int = 128, num_bins: int = 6
+    ) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(feature_dim, hidden_dim),
+            nn.ReLU(inplace=True),
+            nn.Linear(hidden_dim, num_bins),
+        )
+
+    def forward(self, h: torch.Tensor) -> torch.Tensor:
+        return torch.softmax(self.net(h), dim=-1)
+
+
+class AutoFiGSS(nn.Module):
+    """Twin-branch GSS module: E_θ1, E_θ2 + G_φ1, G_φ2."""
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        s: int = 30,
+        t: int = 100,
+        feature_dim: int = 128,
+        num_bins: int = 6,
+    ) -> None:
+        super().__init__()
+        self.encoder1 = AutoFiCNN(in_channels, s, t, feature_dim)
+        self.encoder2 = AutoFiCNN(in_channels, s, t, feature_dim)
+        self.head1 = AutoFiHead(feature_dim, feature_dim, num_bins)
+        self.head2 = AutoFiHead(feature_dim, feature_dim, num_bins)
+
+    def forward(self, x1: torch.Tensor, x2: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        p1 = self.head1(self.encoder1(x1))
+        p2 = self.head2(self.encoder2(x2))
+        return p1, p2
+
+
+# ---------------------------------------------------------------------------
+# Losses
+
+
+def _kl(p: torch.Tensor, q: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    return (p * (torch.log(p + eps) - torch.log(q + eps))).sum(dim=-1)
+
+
+def probability_consistency_loss(p1: torch.Tensor, p2: torch.Tensor) -> torch.Tensor:
+    """L_p (eq. 3): symmetric KL between P1 and P2."""
+    return 0.5 * (_kl(p1, p2).mean() + _kl(p2, p1).mean())
+
+
+def _entropy(p: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    return -(p * torch.log(p + eps)).sum(dim=-1)
+
+
+def mutual_info_loss(p1: torch.Tensor, p2: torch.Tensor) -> torch.Tensor:
+    """L_m (eq. 5): h(E[P]) + E[h(P)], summed over both views.
+
+    Paper formula: L_m = h(E[P]) + E[h(P)]. Driving this *down* in the
+    overall L = L_p + λL_m + γL_g schedule corresponds to maximising
+    mutual information (paper §III.B): the model is pushed to (a) make
+    individual predictions confident — low E[h(P)] — and (b) make the
+    batch-averaged prediction uniform — high h(E[P]).
+
+    We follow the paper literally: a single scalar that sums those two
+    terms and is added to the total loss with the +λ sign.
+    """
+    pm1 = p1.mean(dim=0)
+    pm2 = p2.mean(dim=0)
+    return (
+        _entropy(pm1) + _entropy(pm2) + _entropy(p1).mean() + _entropy(p2).mean()
+    )
+
+
+def _cosine_kernel(a: torch.Tensor, b: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    """K(a, b) = 0.5 (a·b / (||a||·||b||) + 1) — eq. 7."""
+    na = a / (a.norm(dim=-1, keepdim=True) + eps)
+    nb = b / (b.norm(dim=-1, keepdim=True) + eps)
+    return 0.5 * (na @ nb.t() + 1.0)
+
+
+def geometric_loss(p1: torch.Tensor, p2: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    """L_g (eq. 8): KL between Q-distributions of the two views.
+
+    For each sample x^i, Q^i is the row q_{i|j} = K(P^i, P^j) /
+    Σ_{m≠j} K(P^m, P^j). We use cosine similarity (eq. 7).
+    """
+    k1 = _cosine_kernel(p1, p1)
+    k2 = _cosine_kernel(p2, p2)
+    # Zero out self-similarity per the "m ≠ j" qualifier in eq. 6.
+    n = k1.shape[0]
+    mask = 1.0 - torch.eye(n, device=k1.device, dtype=k1.dtype)
+    k1 = k1 * mask
+    k2 = k2 * mask
+    q1 = k1 / (k1.sum(dim=0, keepdim=True) + eps)
+    q2 = k2 / (k2.sum(dim=0, keepdim=True) + eps)
+    return _kl(q1.t(), q2.t()).mean()
+
+
+def autofi_total_loss(
+    p1: torch.Tensor,
+    p2: torch.Tensor,
+    *,
+    lam: float = 1.0,
+    gamma: float = 1000.0,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    """L = L_p + λ·L_m + γ·L_g — paper eq. 9 with λ=1, γ=1000."""
+    lp = probability_consistency_loss(p1, p2)
+    lm = mutual_info_loss(p1, p2)
+    lg = geometric_loss(p1, p2)
+    total = lp + lam * lm + gamma * lg
+    parts = {"L_p": float(lp.item()), "L_m": float(lm.item()), "L_g": float(lg.item())}
+    return total, parts
+
+
+# ---------------------------------------------------------------------------
+# Pre-training loop
+
+def _to_autofi_input(x: torch.Tensor) -> torch.Tensor:
+    """(B, T, S, A) -> (B, A, S, T)."""
+    return x.permute(0, 3, 2, 1).contiguous()
+
+
+def pretrain_autofi(
+    model: AutoFiGSS,
+    loader: DataLoader,
+    *,
+    epochs: int = 300,
+    lr: float = 0.01,
+    momentum: float = 0.9,
+    sigma: float = 0.05,
+    lam: float = 1.0,
+    gamma: float = 1000.0,
+    device: str = "cpu",
+    augment_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
+) -> list[float]:
+    """AutoFi GSS training. SGD lr=0.01, momentum=0.9 per the paper.
+
+    Returns the per-epoch mean total-loss list.
+    """
+    model.to(device)
+    model.train()
+    optim = torch.optim.SGD(model.parameters(), lr=lr, momentum=momentum)
+    aug = augment_fn or (lambda x: autofi_augment(x, sigma=sigma))
+    epoch_losses: list[float] = []
+    for _ in range(epochs):
+        batch_losses: list[float] = []
+        for batch in loader:
+            x = batch[0] if isinstance(batch, (list, tuple)) else batch
+            x = x.to(device).float()
+            v1 = _to_autofi_input(aug(x))
+            v2 = _to_autofi_input(aug(x))
+            p1, p2 = model(v1, v2)
+            loss, _ = autofi_total_loss(p1, p2, lam=lam, gamma=gamma)
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+            batch_losses.append(float(loss.item()))
+        epoch_losses.append(sum(batch_losses) / max(1, len(batch_losses)))
+    return epoch_losses

--- a/src/slices/josiah/run.py
+++ b/src/slices/josiah/run.py
@@ -26,7 +26,8 @@ import torch
 from torch.utils.data import DataLoader
 
 from .augmentations import gaussian_then_mask, random_crop
-from .data import CSI_A, CSI_S, NUM_CLASSES, StubCSI, Widar3CrossSubject
+from .autofi import AutoFiCNN, AutoFiGSS, pretrain_autofi
+from .data import CSI_A, CSI_S, CSI_T, NUM_CLASSES, StubCSI, Widar3CrossSubject
 from .encoder import SupervisedClassifier, TinyCNN, count_parameters
 from .eval import evaluate, linear_probe, train_supervised
 from .ssl import SimCLR, pretrain_simclr
@@ -36,6 +37,36 @@ def set_seed(seed: int) -> None:
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
+
+
+@torch.no_grad()
+def _autofi_linear_probe(
+    encoder: AutoFiCNN,
+    train_loader: DataLoader,
+    test_loader: DataLoader,
+    *,
+    device: str,
+    seed: int,
+) -> float:
+    """Frozen-encoder linear probe for AutoFi (expects (B, A, S, T) input)."""
+    from sklearn.linear_model import LogisticRegression
+
+    encoder.eval().to(device)
+
+    def _features(loader: DataLoader) -> tuple[np.ndarray, np.ndarray]:
+        feats: list[np.ndarray] = []
+        labels: list[np.ndarray] = []
+        for x, y in loader:
+            x = x.to(device).float().permute(0, 3, 2, 1).contiguous()
+            h = encoder(x)
+            feats.append(h.cpu().numpy())
+            labels.append(np.asarray(y))
+        return np.concatenate(feats, axis=0), np.concatenate(labels, axis=0)
+
+    tr_x, tr_y = _features(train_loader)
+    te_x, te_y = _features(test_loader)
+    clf = LogisticRegression(max_iter=1000, random_state=seed).fit(tr_x, tr_y)
+    return float(np.mean(clf.predict(te_x) == te_y))
 
 
 def _make_datasets(
@@ -90,6 +121,35 @@ def main(
         print(f"[josiah] supervised top-1 accuracy: {acc:.3f}")
         return acc
 
+    if mode == "autofi":
+        # T5.4: AutoFi exact reproduction (Yang et al. 2022). Twin-branch GSS
+        # pre-training on (A=3, S=30, T=CSI_T) Conv2d inputs, then linear-probe
+        # the first feature extractor on the labelled set. Paper uses SGD
+        # lr=0.01 momentum=0.9 batch 128 for 300 epochs; CLI defaults stay
+        # small for the smoke loop.
+        gss = AutoFiGSS(in_channels=CSI_A, s=CSI_S, t=CSI_T, feature_dim=128,
+                        num_bins=NUM_CLASSES)
+        print(f"[T5.4] GSS params: {count_parameters(gss)}")
+        losses = pretrain_autofi(
+            gss,
+            train_loader,
+            epochs=epochs,
+            lr=0.01,
+            momentum=0.9,
+            sigma=0.05,
+            lam=1.0,
+            gamma=1000.0,
+            device=device,
+        )
+        print(f"[T5.4] GSS pre-train losses: {[round(loss, 4) for loss in losses]}")
+
+        probe_train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=False)
+        acc = _autofi_linear_probe(
+            gss.encoder1, probe_train_loader, test_loader, device=device, seed=seed
+        )
+        print(f"[T5.4] AutoFi linear-probe accuracy: {acc:.3f}")
+        return acc
+
     if mode in ("simclr-trivial", "simclr-handcrafted"):
         tag = "T5.3" if mode == "simclr-trivial" else "T5.6"
         augment_fn = random_crop if mode == "simclr-trivial" else gaussian_then_mask
@@ -126,11 +186,12 @@ def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser()
     p.add_argument(
         "--mode",
-        choices=["supervised", "simclr-trivial", "simclr-handcrafted"],
+        choices=["supervised", "simclr-trivial", "simclr-handcrafted", "autofi"],
         default="supervised",
         help=(
             "Baseline mode: supervised (T5.1/T5.2), simclr-trivial (T5.3), "
-            "simclr-handcrafted (T5.6, the comparison-column row)."
+            "simclr-handcrafted (T5.6, the comparison-column row), "
+            "autofi (T5.4, exact reproduction of Yang et al. 2022)."
         ),
     )
     p.add_argument("--seed", type=int, default=42)

--- a/tests/slices/josiah/test_autofi.py
+++ b/tests/slices/josiah/test_autofi.py
@@ -1,0 +1,87 @@
+"""Tests for the AutoFi exact reproduction (T5.4)."""
+
+from __future__ import annotations
+
+import torch
+
+from src.slices.josiah.autofi import (
+    AutoFiCNN,
+    AutoFiGSS,
+    autofi_augment,
+    autofi_total_loss,
+    geometric_loss,
+    mutual_info_loss,
+    pretrain_autofi,
+    probability_consistency_loss,
+)
+from src.slices.josiah.data import CSI_A, CSI_S, CSI_T, NUM_CLASSES, StubCSI
+
+
+def test_autofi_cnn_forward_shape() -> None:
+    enc = AutoFiCNN(in_channels=CSI_A, s=CSI_S, t=CSI_T, feature_dim=128)
+    x = torch.randn(2, CSI_A, CSI_S, CSI_T)
+    out = enc(x)
+    assert out.shape == (2, 128)
+
+
+def test_autofi_gss_returns_two_softmax_distributions() -> None:
+    gss = AutoFiGSS(in_channels=CSI_A, s=CSI_S, t=CSI_T, num_bins=NUM_CLASSES)
+    x1 = torch.randn(4, CSI_A, CSI_S, CSI_T)
+    x2 = torch.randn(4, CSI_A, CSI_S, CSI_T)
+    p1, p2 = gss(x1, x2)
+    assert p1.shape == p2.shape == (4, NUM_CLASSES)
+    assert torch.allclose(p1.sum(dim=-1), torch.ones(4), atol=1e-5)
+    assert torch.allclose(p2.sum(dim=-1), torch.ones(4), atol=1e-5)
+
+
+def test_probability_consistency_zero_for_identical_distributions() -> None:
+    p = torch.tensor([[0.2, 0.3, 0.5], [0.1, 0.6, 0.3]])
+    lp = probability_consistency_loss(p, p)
+    assert lp.item() < 1e-6
+
+
+def test_probability_consistency_positive_for_different_distributions() -> None:
+    p1 = torch.tensor([[0.9, 0.05, 0.05]])
+    p2 = torch.tensor([[0.05, 0.05, 0.9]])
+    assert probability_consistency_loss(p1, p2).item() > 1.0
+
+
+def test_mutual_info_loss_runs() -> None:
+    p1 = torch.softmax(torch.randn(8, NUM_CLASSES), dim=-1)
+    p2 = torch.softmax(torch.randn(8, NUM_CLASSES), dim=-1)
+    lm = mutual_info_loss(p1, p2)
+    assert lm.dim() == 0 and torch.isfinite(lm)
+
+
+def test_geometric_loss_zero_for_identical_views() -> None:
+    torch.manual_seed(0)
+    p = torch.softmax(torch.randn(6, NUM_CLASSES), dim=-1)
+    lg = geometric_loss(p, p)
+    assert lg.item() < 1e-5
+
+
+def test_autofi_total_loss_returns_scalar_and_parts() -> None:
+    p1 = torch.softmax(torch.randn(4, NUM_CLASSES), dim=-1)
+    p2 = torch.softmax(torch.randn(4, NUM_CLASSES), dim=-1)
+    total, parts = autofi_total_loss(p1, p2, lam=1.0, gamma=1000.0)
+    assert total.dim() == 0
+    assert set(parts) == {"L_p", "L_m", "L_g"}
+
+
+def test_autofi_augment_adds_gaussian_noise() -> None:
+    torch.manual_seed(0)
+    x = torch.zeros(2, 10, CSI_S, CSI_A)
+    out = autofi_augment(x, sigma=0.1)
+    assert out.shape == x.shape
+    assert out.abs().mean().item() > 0  # noise added
+
+
+def test_pretrain_autofi_smoke() -> None:
+    """Two epochs of GSS training on stub data — verifies the loop runs."""
+    torch.manual_seed(0)
+    ds = StubCSI(num_samples=8, seed=0)
+    loader = torch.utils.data.DataLoader(ds, batch_size=4, shuffle=True, drop_last=True)
+    gss = AutoFiGSS(in_channels=CSI_A, s=CSI_S, t=CSI_T, num_bins=NUM_CLASSES)
+    losses = pretrain_autofi(gss, loader, epochs=2, lr=0.01, momentum=0.9)
+    assert len(losses) == 2
+    assert all(torch.isfinite(torch.tensor(loss)) for loss in losses)


### PR DESCRIPTION
## Summary

Exact reproduction of AutoFi GSS pre-training per Yang et al. 2022 (IEEE IoT Journal, arxiv 2205.01629). Implemented per §III.B and Table I.

- **\`autofi.py\`** — \`AutoFiCNN\` (6-layer Conv2d, Table I), \`AutoFiGSS\` twin-branch module, all three losses (\`probability_consistency_loss\` eq. 3, \`mutual_info_loss\` eq. 5, \`geometric_loss\` eqs. 6–8), and \`pretrain_autofi\` with the paper's optimiser (SGD lr=0.01 momentum=0.9, λ=1, γ=1000).
- **\`run.py\`** — \`--mode autofi\` runs the 300-epoch GSS pre-training then linear-probes the first feature extractor on the labelled set.
- **Layer-1 adaptation.** The paper's input is 3×114×500 (Atheros tool); our Intel 5300 / Widar3.0 input is 3×30×100. The paper explicitly says: *"The first layer of the GSS module is slightly modified to match the input size."* We follow that — keep layer-2..6 kernels exact; scale the layer-1 (15,23)/stride-9 to (5,9)/stride-3.

## Test plan

- [x] \`pytest tests/slices/josiah/test_autofi.py\` — 9 passing.
- [x] \`pytest tests/slices/josiah/\` — 27 passing (full slice).
- [x] \`python -m src.slices.josiah.run --mode autofi --epochs 2\` — green end-to-end on stub.
- [ ] Full 300-epoch real-data run + 3-seed comparison row (follow-up).